### PR TITLE
fix(auth): verificacion de ID Token de Firebase y resolucion de usuario local

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -72,3 +72,7 @@ FRONT_URL=http://localhost:5173
 NOTIFICATION_URL=https://el-cartucho.vercel.app/ed/webhook/mercadopago
 PEDIDO_EXPIRATION_HOURS=72
 PEDIDO_LEGACY_EXPIRATION_HOURS=96
+
+# Firebase Configuration
+FIREBASE_PROJECT_ID=el-cartucho-firebase
+

--- a/app/Http/Controllers/CarritoController.php
+++ b/app/Http/Controllers/CarritoController.php
@@ -2,24 +2,18 @@
 
 namespace App\Http\Controllers;
 
-use Illuminate\Http\Request;
 use App\Models\Carrito;
 use App\Models\Producto;
+use Illuminate\Http\Request;
 
 class CarritoController extends Controller
 {
-    private function getUid(Request $request): ?string
-    {
-        return $request->header('X-Firebase-UID');
-    }
-
     public function index(Request $request)
     {
-        $uid = $this->getUid($request);
-        if (!$uid) return response()->json(['error' => 'No autenticado'], 401);
+        $userId = $request->user()->id;
 
         $items = Carrito::with(['producto.imagenes'])
-            ->where('firebase_uid', $uid)
+            ->where('user_id', $userId)
             ->get()
             ->map(function ($item) {
                 $producto = $item->producto;
@@ -39,19 +33,17 @@ class CarritoController extends Controller
 
     public function upsert(Request $request)
     {
-        $uid = $this->getUid($request);
-        if (!$uid) return response()->json(['error' => 'No autenticado'], 401);
-
         $request->validate([
             'producto_id' => 'required|exists:productos,id',
             'cantidad'    => 'required|integer|min:1',
         ]);
 
+        $userId   = $request->user()->id;
         $producto = Producto::findOrFail($request->producto_id);
         $cantidad = min($request->cantidad, $producto->stock);
 
         $item = Carrito::updateOrCreate(
-            ['firebase_uid' => $uid, 'producto_id' => $request->producto_id],
+            ['user_id' => $userId, 'producto_id' => $request->producto_id],
             ['cantidad' => $cantidad]
         );
 
@@ -60,10 +52,7 @@ class CarritoController extends Controller
 
     public function removeItem(Request $request, int $productoId)
     {
-        $uid = $this->getUid($request);
-        if (!$uid) return response()->json(['error' => 'No autenticado'], 401);
-
-        Carrito::where('firebase_uid', $uid)
+        Carrito::where('user_id', $request->user()->id)
             ->where('producto_id', $productoId)
             ->delete();
 
@@ -72,10 +61,7 @@ class CarritoController extends Controller
 
     public function clear(Request $request)
     {
-        $uid = $this->getUid($request);
-        if (!$uid) return response()->json(['error' => 'No autenticado'], 401);
-
-        Carrito::where('firebase_uid', $uid)->delete();
+        Carrito::where('user_id', $request->user()->id)->delete();
 
         return response()->json(['ok' => true]);
     }

--- a/app/Http/Controllers/PedidoController.php
+++ b/app/Http/Controllers/PedidoController.php
@@ -274,7 +274,7 @@ class PedidoController extends Controller
             'productos.*.cantidad' => 'required|integer|min:1',
         ]);
 
-        $firebaseUid = $request->header('X-Firebase-UID', 'anonimo');
+        $user = $request->user();
 
         DB::beginTransaction();
 
@@ -286,10 +286,10 @@ class PedidoController extends Controller
             $expiracion = now()->addHours(config('mercadopago.expiration_hours', 72));
 
             $pedido = Pedido::create([
-                'firebase_uid' => $firebaseUid,
-                'estado' => 'pendiente',
-                'total' => 0,
-                'expira_at' => $expiracion,
+                'firebase_uid' => $user->firebase_uid,
+                'estado'       => 'pendiente',
+                'total'        => 0,
+                'expira_at'    => $expiracion,
             ]);
 
             foreach ($request->productos as $item) {
@@ -420,25 +420,24 @@ class PedidoController extends Controller
 
     public function misPedidos(Request $request)
     {
-        $uid = $request->header('X-Firebase-UID');
-        if (!$uid) return response()->json(['error' => 'No autenticado'], 401);
+        $user = $request->user();
 
         $pedidos = Pedido::with(['detalles.producto.imagenes'])
-            ->where('firebase_uid', $uid)
+            ->where('firebase_uid', $user->firebase_uid)
             ->orderByDesc('created_at')
             ->get()
             ->map(function ($pedido) {
                 return [
-                    'id'          => $pedido->id,
-                    'estado'      => $pedido->estado,
-                    'total'       => (float) $pedido->total,
-                    'created_at'  => $pedido->created_at,
-                    'productos'   => $pedido->detalles->map(function ($d) {
+                    'id'         => $pedido->id,
+                    'estado'     => $pedido->estado,
+                    'total'      => (float) $pedido->total,
+                    'created_at' => $pedido->created_at,
+                    'productos'  => $pedido->detalles->map(function ($d) {
                         return [
-                            'nombre'         => optional($d->producto)->nombre ?? 'Producto eliminado',
-                            'cantidad'       => $d->cantidad,
-                            'precio_unitario'=> (float) $d->precio_unitario,
-                            'image'          => optional($d->producto?->imagenes->first())->url,
+                            'nombre'          => optional($d->producto)->nombre ?? 'Producto eliminado',
+                            'cantidad'        => $d->cantidad,
+                            'precio_unitario' => (float) $d->precio_unitario,
+                            'image'           => optional($d->producto?->imagenes->first())->url,
                         ];
                     }),
                 ];

--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -2,51 +2,47 @@
 
 namespace App\Http\Controllers;
 
-use Illuminate\Http\Request;
+use App\Http\Resources\UserProfileResource;
 use App\Models\User;
+use Illuminate\Http\Request;
+use Illuminate\Support\Str;
 
 class ProfileController extends Controller
 {
     /**
-     * Obtener o crear el perfil del usuario autenticado via Firebase.
+     * Obtener o crear el perfil del usuario autenticado vía Firebase.
+     *
+     * Este endpoint solo requiere token verificado (middleware firebase.token).
+     * Tolera que el usuario local no exista aún: lo crea con firstOrCreate.
+     * Los datos del usuario vienen del payload verificado, no de headers.
      */
     public function getProfile(Request $request)
     {
-        $uid = $request->header('X-Firebase-UID');
-        if (!$uid) {
-            return response()->json(['error' => 'No autenticado'], 401);
-        }
+        // Los atributos fueron inyectados por VerificarTokenFirebase
+        $uid   = $request->attributes->get('firebase_uid');
+        $email = $request->attributes->get('firebase_email');
+        $name  = $request->attributes->get('firebase_name');
 
         $user = User::firstOrCreate(
             ['firebase_uid' => $uid],
             [
-                'name'     => $request->header('X-User-Name', ''),
-                'email'    => $request->header('X-User-Email', ''),
-                'password' => bcrypt(str()->random(32)),
+                'name'     => $name,
+                'email'    => $email,
+                'password' => bcrypt(Str::random(32)),
             ]
         );
 
-        return response()->json([
-            'id'            => $user->id,
-            'name'          => $user->name,
-            'email'         => $user->email,
-            'apellido'      => $user->apellido,
-            'domicilio'     => $user->domicilio,
-            'ciudad'        => $user->ciudad,
-            'codigo_postal' => $user->codigo_postal,
-        ]);
+        return new UserProfileResource($user);
     }
 
     /**
-     * Actualizar el perfil del usuario autenticado via Firebase.
+     * Actualizar el perfil del usuario autenticado vía Firebase.
+     *
+     * Requiere token verificado + usuario local existente (firebase.token + firebase.user).
+     * Solo se actualizan los campos editables; el email nunca se modifica desde aquí.
      */
     public function updateProfile(Request $request)
     {
-        $uid = $request->header('X-Firebase-UID');
-        if (!$uid) {
-            return response()->json(['error' => 'No autenticado'], 401);
-        }
-
         $request->validate([
             'name'          => 'sometimes|string|max:255',
             'apellido'      => 'sometimes|nullable|string|max:255',
@@ -55,24 +51,11 @@ class ProfileController extends Controller
             'codigo_postal' => 'sometimes|nullable|string|max:20',
         ]);
 
-        $user = User::where('firebase_uid', $uid)->first();
-
-        if (!$user) {
-            return response()->json(['error' => 'Usuario no encontrado'], 404);
-        }
-
+        $user = $request->user();
         $user->update($request->only([
-            'name', 'apellido', 'domicilio', 'ciudad', 'codigo_postal'
+            'name', 'apellido', 'domicilio', 'ciudad', 'codigo_postal',
         ]));
 
-        return response()->json([
-            'id'            => $user->id,
-            'name'          => $user->name,
-            'email'         => $user->email,
-            'apellido'      => $user->apellido,
-            'domicilio'     => $user->domicilio,
-            'ciudad'        => $user->ciudad,
-            'codigo_postal' => $user->codigo_postal,
-        ]);
+        return new UserProfileResource($user);
     }
 }

--- a/app/Http/Controllers/WishlistController.php
+++ b/app/Http/Controllers/WishlistController.php
@@ -2,35 +2,29 @@
 
 namespace App\Http\Controllers;
 
-use Illuminate\Http\Request;
 use App\Models\Wishlist;
+use Illuminate\Http\Request;
 
 class WishlistController extends Controller
 {
-    private function getUid(Request $request): ?string
-    {
-        return $request->header('X-Firebase-UID');
-    }
-
     public function index(Request $request)
     {
-        $uid = $this->getUid($request);
-        if (!$uid) return response()->json(['error' => 'No autenticado'], 401);
+        $userId = $request->user()->id;
 
         $items = Wishlist::with(['producto.imagenes'])
-            ->where('firebase_uid', $uid)
+            ->where('user_id', $userId)
             ->get()
             ->map(function ($item) {
                 $producto = $item->producto;
                 $imagen = $producto->imagenes->first()?->url ?? null;
                 return [
-                    'wishlist_id'  => $item->id,
-                    'producto_id'  => $producto->id,
-                    'nombre'       => $producto->nombre,
-                    'precio'       => (float) $producto->precioUnitario,
-                    'stock'        => $producto->stock,
-                    'image'        => $imagen,
-                    'created_at'   => $item->created_at,
+                    'wishlist_id' => $item->id,
+                    'producto_id' => $producto->id,
+                    'nombre'      => $producto->nombre,
+                    'precio'      => (float) $producto->precioUnitario,
+                    'stock'       => $producto->stock,
+                    'image'       => $imagen,
+                    'created_at'  => $item->created_at,
                 ];
             });
 
@@ -39,12 +33,11 @@ class WishlistController extends Controller
 
     public function toggle(Request $request)
     {
-        $uid = $this->getUid($request);
-        if (!$uid) return response()->json(['error' => 'No autenticado'], 401);
-
         $request->validate(['producto_id' => 'required|exists:productos,id']);
 
-        $existing = Wishlist::where('firebase_uid', $uid)
+        $userId = $request->user()->id;
+
+        $existing = Wishlist::where('user_id', $userId)
             ->where('producto_id', $request->producto_id)
             ->first();
 
@@ -54,8 +47,8 @@ class WishlistController extends Controller
         }
 
         Wishlist::create([
-            'firebase_uid' => $uid,
-            'producto_id'  => $request->producto_id,
+            'user_id'    => $userId,
+            'producto_id' => $request->producto_id,
         ]);
 
         return response()->json(['action' => 'added']);
@@ -63,10 +56,7 @@ class WishlistController extends Controller
 
     public function check(Request $request, int $productoId)
     {
-        $uid = $this->getUid($request);
-        if (!$uid) return response()->json(['in_wishlist' => false]);
-
-        $inWishlist = Wishlist::where('firebase_uid', $uid)
+        $inWishlist = Wishlist::where('user_id', $request->user()->id)
             ->where('producto_id', $productoId)
             ->exists();
 
@@ -75,10 +65,7 @@ class WishlistController extends Controller
 
     public function remove(Request $request, int $productoId)
     {
-        $uid = $this->getUid($request);
-        if (!$uid) return response()->json(['error' => 'No autenticado'], 401);
-
-        Wishlist::where('firebase_uid', $uid)
+        Wishlist::where('user_id', $request->user()->id)
             ->where('producto_id', $productoId)
             ->delete();
 

--- a/app/Http/Middleware/RequerirUsuarioLocal.php
+++ b/app/Http/Middleware/RequerirUsuarioLocal.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Models\User;
+use Closure;
+use Illuminate\Http\Request;
+
+/**
+ * Resuelve el usuario local a partir del firebase_uid verificado.
+ *
+ * Debe ejecutarse DESPUÉS de VerificarTokenFirebase en la cadena de middleware.
+ * Si el uid verificado no corresponde a ningún User local, responde 401.
+ *
+ * GET /profile NO usa este middleware: tolera que el usuario no exista
+ * localmente (lo crea él mismo con firstOrCreate).
+ */
+class RequerirUsuarioLocal
+{
+    public function handle(Request $request, Closure $next): mixed
+    {
+        $uid = $request->attributes->get('firebase_uid');
+
+        if (!$uid) {
+            // El middleware VerificarTokenFirebase no corrió antes — configuración incorrecta
+            return response()->json(['error' => 'Token no verificado.'], 401);
+        }
+
+        $user = User::where('firebase_uid', $uid)->first();
+
+        if (!$user) {
+            return response()->json(['error' => 'Usuario no encontrado. Iniciá sesión para registrarte.'], 401);
+        }
+
+        // Inyectar usuario en el request para que $request->user() funcione en controllers
+        $request->setUserResolver(fn() => $user);
+
+        return $next($request);
+    }
+}

--- a/app/Http/Middleware/VerificarTokenFirebase.php
+++ b/app/Http/Middleware/VerificarTokenFirebase.php
@@ -1,0 +1,201 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Firebase\JWT\JWT;
+use Firebase\JWT\Key;
+use Firebase\JWT\ExpiredException;
+use Firebase\JWT\SignatureInvalidException;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Verifica la firma del ID token de Firebase.
+ *
+ * Responsabilidad única: leer el header Authorization: Bearer <token>,
+ * verificar la firma contra las claves públicas de Google, y poner los
+ * claims verificados (firebase_uid, firebase_email, firebase_name) en
+ * los atributos del request.
+ *
+ * No resuelve ni crea el usuario local. Eso lo hace RequerirUsuarioLocal
+ * o el propio controller (en el caso de GET /profile).
+ */
+class VerificarTokenFirebase
+{
+    private const CACHE_KEY      = 'firebase_public_keys';
+    private const LOCK_KEY       = 'firebase_keys_fetch_lock';
+    private const MAX_TTL        = 3600;
+    private const LOCK_SECONDS   = 10;
+    private const BLOCK_SECONDS  = 5;
+
+    public function handle(Request $request, Closure $next): mixed
+    {
+        $bearer = $request->bearerToken();
+
+        if (!$bearer) {
+            return $this->noAutorizado('Token de autorización ausente.');
+        }
+
+        try {
+            $payload = $this->decodificarToken($bearer);
+        } catch (\Throwable $e) {
+            Log::debug('VerificarTokenFirebase: token rechazado — ' . $e->getMessage());
+            return $this->noAutorizado('Token inválido.');
+        }
+
+        // Validar issuer y audience
+        $projectId = config('firebase.project_id');
+        $issEsperado = "https://securetoken.google.com/{$projectId}";
+
+        if (($payload->iss ?? '') !== $issEsperado) {
+            return $this->noAutorizado('Issuer inválido.');
+        }
+
+        if (($payload->aud ?? '') !== $projectId) {
+            return $this->noAutorizado('Audience inválido.');
+        }
+
+        // Inyectar claims verificados en atributos del request
+        $request->attributes->set('firebase_uid',   $payload->sub ?? $payload->uid ?? '');
+        $request->attributes->set('firebase_email', $payload->email ?? '');
+        $request->attributes->set('firebase_name',  $payload->name ?? '');
+
+        return $next($request);
+    }
+
+    /**
+     * Decodifica y verifica el token JWT.
+     * Si el kid no está en el bundle cacheado, invalida el caché y reintenta una vez.
+     */
+    private function decodificarToken(string $token): object
+    {
+        // Extraer kid del header sin verificar (no trusted, solo para lookup de clave)
+        $kid = $this->extraerKidDelHeader($token);
+
+        $claves = $this->obtenerClavesPublicas();
+
+        // Si el kid no está en el bundle cacheado, refrescar una sola vez
+        if ($kid !== null && !array_key_exists($kid, $claves)) {
+            Cache::forget(self::CACHE_KEY);
+            $claves = $this->obtenerClavesPublicas();
+            // Si sigue sin estar, JWT::decode fallará y lanzará excepción → 401
+        }
+
+        return JWT::decode($token, $claves);
+    }
+
+    /**
+     * Obtiene las claves públicas de Google, usando caché en base de datos.
+     *
+     * Patrón check-lock-check para evitar el thundering herd:
+     * solo una invocación descarga las claves cuando el caché expira;
+     * las demás esperan hasta BLOCK_SECONDS y luego leen el valor recién cacheado.
+     *
+     * @return array<string, Key>
+     */
+    private function obtenerClavesPublicas(): array
+    {
+        // Camino rápido: hit de caché
+        $cacheado = Cache::get(self::CACHE_KEY);
+        if ($cacheado !== null) {
+            return $this->construirKeySet($cacheado);
+        }
+
+        // Camino lento: el caché expiró — tomar el lock distribuido
+        $lock = Cache::lock(self::LOCK_KEY, self::LOCK_SECONDS);
+
+        try {
+            $lock->block(self::BLOCK_SECONDS);
+
+            // Double-check: otra invocación puede haber llenado el caché mientras esperábamos
+            $cacheado = Cache::get(self::CACHE_KEY);
+            if ($cacheado !== null) {
+                return $this->construirKeySet($cacheado);
+            }
+
+            // Somos los únicos descargando ahora
+            return $this->descargarYCachearClaves();
+
+        } catch (\Illuminate\Contracts\Cache\LockTimeoutException $e) {
+            // No pudimos adquirir el lock en BLOCK_SECONDS — descargamos directamente
+            // como fallback para no bloquear al usuario.
+            Log::warning('VerificarTokenFirebase: timeout esperando lock de claves. Descargando directamente.');
+            return $this->descargarYCachearClaves();
+        } finally {
+            optional($lock)->release();
+        }
+    }
+
+    /**
+     * Descarga las claves de Google, las cachea con TTL del header Cache-Control
+     * (máximo MAX_TTL segundos) y devuelve el KeySet.
+     *
+     * @return array<string, Key>
+     */
+    private function descargarYCachearClaves(): array
+    {
+        $response = Http::timeout(5)
+            ->get(config('firebase.keys_url'));
+
+        $response->throw(); // Lanza HttpClientException si falla
+
+        // Parsear TTL desde Cache-Control: max-age=N
+        $ttl = self::MAX_TTL;
+        $cacheControl = $response->header('Cache-Control') ?? '';
+        if (preg_match('/max-age=(\d+)/i', $cacheControl, $matches)) {
+            $ttl = min((int)$matches[1], self::MAX_TTL);
+        }
+
+        $certs = $response->json(); // ["kid" => "-----BEGIN CERTIFICATE-----\n..."]
+
+        Cache::put(self::CACHE_KEY, $certs, $ttl);
+
+        return $this->construirKeySet($certs);
+    }
+
+    /**
+     * Convierte el array de certificados X.509 en un KeySet de firebase/php-jwt.
+     *
+     * @param  array<string, string> $certs  kid => PEM cert string
+     * @return array<string, Key>
+     */
+    private function construirKeySet(array $certs): array
+    {
+        $keys = [];
+        foreach ($certs as $kid => $certPem) {
+            // openssl_x509_read extrae la clave pública del certificado X.509
+            $certRes = openssl_x509_read($certPem);
+            if ($certRes === false) {
+                continue; // Ignorar certificados mal formados
+            }
+            $pubKeyRes = openssl_pkey_get_public($certRes);
+            if ($pubKeyRes === false) {
+                continue;
+            }
+            $keys[$kid] = new Key($pubKeyRes, 'RS256');
+        }
+        return $keys;
+    }
+
+    /**
+     * Lee el "kid" del header del JWT sin verificar la firma.
+     * El valor no es de confianza para nada más allá del lookup de clave.
+     */
+    private function extraerKidDelHeader(string $token): ?string
+    {
+        $partes = explode('.', $token);
+        if (count($partes) < 2) {
+            return null;
+        }
+        $header = json_decode(base64_decode(strtr($partes[0], '-_', '+/')), true);
+        return $header['kid'] ?? null;
+    }
+
+    private function noAutorizado(string $mensaje): \Illuminate\Http\JsonResponse
+    {
+        return response()->json(['error' => $mensaje], 401);
+    }
+}

--- a/app/Http/Resources/UserProfileResource.php
+++ b/app/Http/Resources/UserProfileResource.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class UserProfileResource extends JsonResource
+{
+    /**
+     * Transforma el usuario en un array para la respuesta de la API.
+     *
+     * El email se omite del perfil editable: siempre viene de Firebase.
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id'            => $this->id,
+            'firebase_uid'  => $this->firebase_uid,
+            'name'          => $this->name,
+            'apellido'      => $this->apellido,
+            'email'         => $this->email,
+            'domicilio'     => $this->domicilio,
+            'ciudad'        => $this->ciudad,
+            'codigo_postal' => $this->codigo_postal,
+            'created_at'    => $this->created_at,
+        ];
+    }
+}

--- a/app/Models/Carrito.php
+++ b/app/Models/Carrito.php
@@ -8,10 +8,15 @@ class Carrito extends Model
 {
     protected $table = 'carrito';
 
-    protected $fillable = ['firebase_uid', 'producto_id', 'cantidad'];
+    protected $fillable = ['user_id', 'firebase_uid', 'producto_id', 'cantidad'];
 
     public function producto()
     {
         return $this->belongsTo(Producto::class);
+    }
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
     }
 }

--- a/app/Models/Wishlist.php
+++ b/app/Models/Wishlist.php
@@ -8,10 +8,15 @@ class Wishlist extends Model
 {
     protected $table = 'wishlist';
 
-    protected $fillable = ['firebase_uid', 'producto_id'];
+    protected $fillable = ['user_id', 'firebase_uid', 'producto_id'];
 
     public function producto()
     {
         return $this->belongsTo(Producto::class)->with('imagenes');
+    }
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
     }
 }

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -14,6 +14,12 @@ return Application::configure(basePath: dirname(__DIR__))
     )
     ->withMiddleware(function (Middleware $middleware) {
         $middleware->trustProxies(at: '*');
+
+        // Verificación de ID token de Firebase (firma + claims)
+        $middleware->alias([
+            'firebase.token' => \App\Http\Middleware\VerificarTokenFirebase::class,
+            'firebase.user'  => \App\Http\Middleware\RequerirUsuarioLocal::class,
+        ]);
     })
     ->withExceptions(function (Exceptions $exceptions) {
         //

--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,7 @@
         "php": "^8.2",
         "barryvdh/laravel-dompdf": "^3.1",
         "cloudinary-labs/cloudinary-laravel": "^3.0",
+        "firebase/php-jwt": "^6.10",
         "laravel/framework": "^12.0",
         "laravel/sanctum": "^4.1",
         "laravel/tinker": "^2.10.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2cb09c630372e431db4fdce90f69f1d4",
+    "content-hash": "3cde702388eaf3d5ae10514cb75c23a5",
     "packages": [
         {
             "name": "barryvdh/laravel-dompdf",
@@ -933,6 +933,69 @@
                 }
             ],
             "time": "2025-03-06T22:45:56+00:00"
+        },
+        {
+            "name": "firebase/php-jwt",
+            "version": "v6.11.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/googleapis/php-jwt.git",
+                "reference": "d1e91ecf8c598d073d0995afa8cd5c75c6e19e66"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/googleapis/php-jwt/zipball/d1e91ecf8c598d073d0995afa8cd5c75c6e19e66",
+                "reference": "d1e91ecf8c598d073d0995afa8cd5c75c6e19e66",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.0"
+            },
+            "require-dev": {
+                "guzzlehttp/guzzle": "^7.4",
+                "phpspec/prophecy-phpunit": "^2.0",
+                "phpunit/phpunit": "^9.5",
+                "psr/cache": "^2.0||^3.0",
+                "psr/http-client": "^1.0",
+                "psr/http-factory": "^1.0"
+            },
+            "suggest": {
+                "ext-sodium": "Support EdDSA (Ed25519) signatures",
+                "paragonie/sodium_compat": "Support EdDSA (Ed25519) signatures when libsodium is not present"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Firebase\\JWT\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Neuman Vong",
+                    "email": "neuman+pear@twilio.com",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Anant Narayanan",
+                    "email": "anant@php.net",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A simple library to encode and decode JSON Web Tokens (JWT) in PHP. Should conform to the current spec.",
+            "homepage": "https://github.com/firebase/php-jwt",
+            "keywords": [
+                "jwt",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/googleapis/php-jwt/issues",
+                "source": "https://github.com/googleapis/php-jwt/tree/v6.11.1"
+            },
+            "time": "2025-04-09T20:32:01+00:00"
         },
         {
             "name": "fruitcake/php-cors",

--- a/config/firebase.php
+++ b/config/firebase.php
@@ -1,0 +1,27 @@
+<?php
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | Firebase Project ID
+    |--------------------------------------------------------------------------
+    |
+    | El ID del proyecto de Firebase. Se usa para validar los claims "iss" y
+    | "aud" de los ID tokens emitidos por Firebase Authentication.
+    |
+    | Se obtiene en la Consola de Firebase → Configuración del proyecto → General.
+    |
+    */
+    'project_id' => env('FIREBASE_PROJECT_ID'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | URL de claves públicas de Google
+    |--------------------------------------------------------------------------
+    |
+    | Google expone los certificados X.509 de Firebase en esta URL.
+    | El TTL del caché se toma del header Cache-Control de la respuesta.
+    |
+    */
+    'keys_url' => 'https://www.googleapis.com/robot/v1/metadata/x509/securetoken@system.gserviceaccount.com',
+];

--- a/database/migrations/2026_08_08_181100_add_user_id_to_carrito_table.php
+++ b/database/migrations/2026_08_08_181100_add_user_id_to_carrito_table.php
@@ -1,0 +1,53 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Agrega user_id a carrito con FK a users y hace el backfill desde firebase_uid.
+     * La columna firebase_uid se conserva como respaldo.
+     * El índice único pasa de [firebase_uid, producto_id] a [user_id, producto_id].
+     */
+    public function up(): void
+    {
+        Schema::table('carrito', function (Blueprint $table) {
+            $table->unsignedBigInteger('user_id')->nullable()->after('firebase_uid');
+            $table->foreign('user_id')->references('id')->on('users')->nullOnDelete();
+        });
+
+        // Backfill compatible con SQLite y PostgreSQL
+        DB::statement("
+            UPDATE carrito
+            SET user_id = (
+                SELECT id FROM users WHERE users.firebase_uid = carrito.firebase_uid
+            )
+            WHERE firebase_uid IS NOT NULL
+        ");
+
+        // Reemplazar el índice único [firebase_uid, producto_id] por [user_id, producto_id]
+        Schema::table('carrito', function (Blueprint $table) {
+            $table->dropUnique(['firebase_uid', 'producto_id']);
+        });
+
+        DB::statement('
+            CREATE UNIQUE INDEX carrito_user_id_producto_id_unique
+            ON carrito (user_id, producto_id)
+            WHERE user_id IS NOT NULL
+        ');
+    }
+
+    public function down(): void
+    {
+        DB::statement('DROP INDEX IF EXISTS carrito_user_id_producto_id_unique');
+
+        Schema::table('carrito', function (Blueprint $table) {
+            $table->dropForeign(['user_id']);
+            $table->dropColumn('user_id');
+            $table->unique(['firebase_uid', 'producto_id']);
+        });
+    }
+};

--- a/database/migrations/2026_08_08_181101_add_user_id_to_wishlist_table.php
+++ b/database/migrations/2026_08_08_181101_add_user_id_to_wishlist_table.php
@@ -1,0 +1,53 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Agrega user_id a wishlist con FK a users y hace el backfill desde firebase_uid.
+     * La columna firebase_uid se conserva como respaldo.
+     * El índice único pasa de [firebase_uid, producto_id] a [user_id, producto_id].
+     */
+    public function up(): void
+    {
+        Schema::table('wishlist', function (Blueprint $table) {
+            $table->unsignedBigInteger('user_id')->nullable()->after('firebase_uid');
+            $table->foreign('user_id')->references('id')->on('users')->nullOnDelete();
+        });
+
+        // Backfill compatible con SQLite y PostgreSQL
+        DB::statement("
+            UPDATE wishlist
+            SET user_id = (
+                SELECT id FROM users WHERE users.firebase_uid = wishlist.firebase_uid
+            )
+            WHERE firebase_uid IS NOT NULL
+        ");
+
+        // Reemplazar el índice único [firebase_uid, producto_id] por [user_id, producto_id]
+        Schema::table('wishlist', function (Blueprint $table) {
+            $table->dropUnique(['firebase_uid', 'producto_id']);
+        });
+
+        DB::statement('
+            CREATE UNIQUE INDEX wishlist_user_id_producto_id_unique
+            ON wishlist (user_id, producto_id)
+            WHERE user_id IS NOT NULL
+        ');
+    }
+
+    public function down(): void
+    {
+        DB::statement('DROP INDEX IF EXISTS wishlist_user_id_producto_id_unique');
+
+        Schema::table('wishlist', function (Blueprint $table) {
+            $table->dropForeign(['user_id']);
+            $table->dropColumn('user_id');
+            $table->unique(['firebase_uid', 'producto_id']);
+        });
+    }
+};

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -30,5 +30,6 @@
         <env name="QUEUE_CONNECTION" value="sync"/>
         <env name="SESSION_DRIVER" value="array"/>
         <env name="TELESCOPE_ENABLED" value="false"/>
+        <env name="FIREBASE_PROJECT_ID" value="el-cartucho-test-project"/>
     </php>
 </phpunit>

--- a/routes/api.php
+++ b/routes/api.php
@@ -10,11 +10,7 @@ use App\Http\Controllers\ProfileController;
 use App\Http\Controllers\CarritoController;
 use App\Http\Controllers\WishlistController;
 
-Route::get('/user', function (Request $request) {
-    return $request->user();
-})->middleware('auth:sanctum');
-
-// Endpoints
+// ─── Sin autenticación ───────────────────────────────────────────────────────
 
 #Mercado Pago
 Route::post('/webhook/mercadopago', [WebhookController::class, 'handle']);
@@ -25,26 +21,36 @@ Route::get('/producto/{id}', [ProductoController::class, 'obtenerProductoConReso
 Route::get('/productosRecientes', [ProductoController::class, 'obtenerProductosRecientes']);
 Route::get('/productosMasVendidos', [ProductoController::class, 'obtenerProductosMasVendidos']);
 
-#Pedidos
-Route::post('/pedido/crear', [PedidoController::class, 'store']);
-Route::get('/pedido/costo/{cp}', [PedidoController::class, 'calcularCostoEnvio']);
-Route::get('/mis-pedidos', [PedidoController::class, 'misPedidos']);
-
 #Categorias
 Route::get('/categorias', [CategoriaController::class, 'apiList']);
 
-#Perfil
-Route::get('/profile', [ProfileController::class, 'getProfile']);
-Route::post('/profile', [ProfileController::class, 'updateProfile']);
+#Envío (cálculo de costo, no requiere usuario)
+Route::get('/pedido/costo/{cp}', [PedidoController::class, 'calcularCostoEnvio']);
 
-#Carrito
-Route::get('/carrito', [CarritoController::class, 'index']);
-Route::post('/carrito', [CarritoController::class, 'upsert']);
-Route::delete('/carrito/{productoId}', [CarritoController::class, 'removeItem']);
-Route::delete('/carrito', [CarritoController::class, 'clear']);
+// ─── Token verificado (sin requerir usuario local) ───────────────────────────
+// GET /profile tolera que el usuario no exista aún; el controller hace firstOrCreate.
+Route::middleware(['firebase.token'])->group(function () {
+    Route::get('/profile', [ProfileController::class, 'getProfile']);
+});
 
-#Wishlist
-Route::get('/wishlist', [WishlistController::class, 'index']);
-Route::post('/wishlist/toggle', [WishlistController::class, 'toggle']);
-Route::get('/wishlist/check/{productoId}', [WishlistController::class, 'check']);
-Route::delete('/wishlist/{productoId}', [WishlistController::class, 'remove']);
+// ─── Token verificado + usuario local existente ──────────────────────────────
+Route::middleware(['firebase.token', 'firebase.user'])->group(function () {
+    #Perfil
+    Route::post('/profile', [ProfileController::class, 'updateProfile']);
+
+    #Pedidos
+    Route::post('/pedido/crear', [PedidoController::class, 'store']);
+    Route::get('/mis-pedidos', [PedidoController::class, 'misPedidos']);
+
+    #Carrito
+    Route::get('/carrito', [CarritoController::class, 'index']);
+    Route::post('/carrito', [CarritoController::class, 'upsert']);
+    Route::delete('/carrito/{productoId}', [CarritoController::class, 'removeItem']);
+    Route::delete('/carrito', [CarritoController::class, 'clear']);
+
+    #Wishlist
+    Route::get('/wishlist', [WishlistController::class, 'index']);
+    Route::post('/wishlist/toggle', [WishlistController::class, 'toggle']);
+    Route::get('/wishlist/check/{productoId}', [WishlistController::class, 'check']);
+    Route::delete('/wishlist/{productoId}', [WishlistController::class, 'remove']);
+});

--- a/tests/Feature/PedidoControllerTest.php
+++ b/tests/Feature/PedidoControllerTest.php
@@ -21,6 +21,13 @@ class PedidoControllerTest extends TestCase
         Config::set('mercadopago.front_url', 'http://localhost:3000');
         Config::set('mercadopago.notification_url', 'http://localhost/webhook');
         Config::set('mercadopago.expiration_hours', 72);
+
+        $user = \App\Models\User::factory()->create(['firebase_uid' => 'test-pedido-uid']);
+        $this->actingAs($user);
+        $this->withoutMiddleware([
+            \App\Http\Middleware\VerificarTokenFirebase::class,
+            \App\Http\Middleware\RequerirUsuarioLocal::class,
+        ]);
     }
 
     /** @test */

--- a/tests/Feature/PedidoControllerTest.php
+++ b/tests/Feature/PedidoControllerTest.php
@@ -2,17 +2,23 @@
 
 namespace Tests\Feature;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Tests\TestCase;
-use App\Models\Pedido;
 use App\Models\Producto;
-use App\Models\DetallePedido;
-use Illuminate\Support\Facades\Http;
+use App\Models\User;
+use Firebase\JWT\JWT;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
 
 class PedidoControllerTest extends TestCase
 {
     use RefreshDatabase;
+
+    private string $privateKeyPem;
+    private string $certPem;
+    private string $kid = 'test-kid-pedido';
+    private string $projectId = 'el-cartucho-test-project';
+    private User $user;
 
     protected function setUp(): void
     {
@@ -22,12 +28,51 @@ class PedidoControllerTest extends TestCase
         Config::set('mercadopago.notification_url', 'http://localhost/webhook');
         Config::set('mercadopago.expiration_hours', 72);
 
-        $user = \App\Models\User::factory()->create(['firebase_uid' => 'test-pedido-uid']);
-        $this->actingAs($user);
-        $this->withoutMiddleware([
-            \App\Http\Middleware\VerificarTokenFirebase::class,
-            \App\Http\Middleware\RequerirUsuarioLocal::class,
+        $openSslConfig = [
+            'digest_alg'       => 'sha256',
+            'private_key_bits' => 2048,
+            'private_key_type' => OPENSSL_KEYTYPE_RSA,
+        ];
+        if (file_exists('C:\lenguajes\php\extras\ssl\openssl.cnf')) {
+            $openSslConfig['config'] = 'C:\lenguajes\php\extras\ssl\openssl.cnf';
+        }
+
+        $dn = ["countryName" => "AR", "organizationName" => "Test", "commonName" => "Test"];
+        $res = openssl_pkey_new($openSslConfig);
+        openssl_pkey_export($res, $keyOut, null, $openSslConfig);
+        $this->privateKeyPem = $keyOut;
+
+        $csr = openssl_csr_new($dn, $res, $openSslConfig);
+        $cert = openssl_csr_sign($csr, null, $res, 365, $openSslConfig);
+        openssl_x509_export($cert, $certOut);
+        $this->certPem = $certOut;
+
+        $this->user = User::factory()->create(['firebase_uid' => 'test-pedido-uid']);
+
+        Http::fake([
+            'https://www.googleapis.com/*' => Http::response([
+                $this->kid => $this->certPem,
+            ], 200, ['Cache-Control' => 'max-age=3600']),
+            'api.mercadopago.com/checkout/preferences' => Http::response([
+                'init_point' => 'https://mercadopago.com/checkout/pay',
+                'id'         => 'pref_12345',
+            ], 200),
         ]);
+    }
+
+    private function tokenHeader(): array
+    {
+        $payload = [
+            'iss'   => "https://securetoken.google.com/{$this->projectId}",
+            'aud'   => $this->projectId,
+            'sub'   => $this->user->firebase_uid,
+            'email' => $this->user->email,
+            'name'  => $this->user->name,
+            'iat'   => time() - 10,
+            'exp'   => time() + 3600,
+        ];
+        $token = JWT::encode($payload, $this->privateKeyPem, 'RS256', $this->kid);
+        return ['Authorization' => "Bearer {$token}"];
     }
 
     /** @test */
@@ -35,14 +80,15 @@ class PedidoControllerTest extends TestCase
     {
         $producto = Producto::factory()->create(['stock' => 5, 'precioUnitario' => 100.0]);
 
-        $response = $this->postJson('/ed/pedido/crear', [
-            'productos' => [
-                [
-                    'producto_id' => $producto->id,
-                    'cantidad' => 6 // Excede stock de 5
+        $response = $this->withHeaders($this->tokenHeader())
+            ->postJson('/ed/pedido/crear', [
+                'productos' => [
+                    [
+                        'producto_id' => $producto->id,
+                        'cantidad'    => 6, // Excede stock de 5
+                    ]
                 ]
-            ]
-        ]);
+            ]);
 
         $response->assertStatus(409);
         $response->assertJsonStructure(['error', 'message']);
@@ -54,37 +100,51 @@ class PedidoControllerTest extends TestCase
     {
         $producto = Producto::factory()->create(['stock' => 1, 'precioUnitario' => 100.0]);
 
-        // Mock de MercadoPago para la creación de preferencia
-        Http::fake([
-            'api.mercadopago.com/checkout/preferences' => Http::response([
-                'init_point' => 'https://mercadopago.com/checkout/pay',
-                'id' => 'pref_12345'
-            ], 200)
-        ]);
-
         // Primer pedido por el único elemento
-        $response1 = $this->postJson('/ed/pedido/crear', [
-            'productos' => [
-                [
-                    'producto_id' => $producto->id,
-                    'cantidad' => 1
+        $response1 = $this->withHeaders($this->tokenHeader())
+            ->postJson('/ed/pedido/crear', [
+                'productos' => [
+                    [
+                        'producto_id' => $producto->id,
+                        'cantidad'    => 1,
+                    ]
                 ]
-            ]
-        ]);
+            ]);
 
         $response1->assertStatus(201);
         $this->assertEquals(0, $producto->fresh()->stock); // Queda en 0
 
         // Segundo pedido concurrente (ya no hay stock)
-        $response2 = $this->postJson('/ed/pedido/crear', [
-            'productos' => [
-                [
-                    'producto_id' => $producto->id,
-                    'cantidad' => 1
+        $response2 = $this->withHeaders($this->tokenHeader())
+            ->postJson('/ed/pedido/crear', [
+                'productos' => [
+                    [
+                        'producto_id' => $producto->id,
+                        'cantidad'    => 1,
+                    ]
                 ]
-            ]
-        ]);
+            ]);
 
         $response2->assertStatus(409); // Falla con 409
+    }
+
+    /** @test */
+    public function order_creation_with_web_session_but_no_firebase_token_returns_401()
+    {
+        $producto = Producto::factory()->create(['stock' => 5, 'precioUnitario' => 100.0]);
+
+        // Iniciar sesión en Laravel (sesión web / actingAs) pero SIN enviar header Authorization Bearer
+        $response = $this->actingAs($this->user)
+            ->postJson('/ed/pedido/crear', [
+                'productos' => [
+                    [
+                        'producto_id' => $producto->id,
+                        'cantidad'    => 1,
+                    ]
+                ]
+            ]);
+
+        $response->assertStatus(401);
+        $response->assertJson(['error' => 'Token de autorización ausente.']);
     }
 }

--- a/tests/Feature/VerificarTokenFirebaseTest.php
+++ b/tests/Feature/VerificarTokenFirebaseTest.php
@@ -1,0 +1,273 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Carrito;
+use App\Models\Pedido;
+use App\Models\Producto;
+use App\Models\User;
+use App\Models\Wishlist;
+use Firebase\JWT\JWT;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+class VerificarTokenFirebaseTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private string $privateKeyPem;
+    private string $certPem;
+    private string $kid = 'test-kid-1';
+    private string $projectId = 'el-cartucho-test-project';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $openSslConfig = [
+            'digest_alg'       => 'sha256',
+            'private_key_bits' => 2048,
+            'private_key_type' => OPENSSL_KEYTYPE_RSA,
+        ];
+        if (file_exists('C:\lenguajes\php\extras\ssl\openssl.cnf')) {
+            $openSslConfig['config'] = 'C:\lenguajes\php\extras\ssl\openssl.cnf';
+        }
+
+        // Generar par de claves y certificado X.509 efímero para tests
+        $dn = ["countryName" => "AR", "organizationName" => "Test", "commonName" => "Test"];
+        $res = openssl_pkey_new($openSslConfig);
+        openssl_pkey_export($res, $keyOut, null, $openSslConfig);
+        $this->privateKeyPem = $keyOut;
+
+        $csr = openssl_csr_new($dn, $res, $openSslConfig);
+        $cert = openssl_csr_sign($csr, null, $res, 365, $openSslConfig);
+        openssl_x509_export($cert, $certOut);
+        $this->certPem = $certOut;
+
+        $this->mockGoogleKeys();
+    }
+
+    private function mockGoogleKeys(?array $keysMap = null): void
+    {
+        Http::swap(new \Illuminate\Http\Client\Factory());
+        $keys = $keysMap ?? [$this->kid => $this->certPem];
+        Http::fake([
+            'https://www.googleapis.com/*' => Http::response($keys, 200, ['Cache-Control' => 'max-age=3600']),
+        ]);
+    }
+
+    private function crearTokenValido(string $uid, string $email = 'test@example.com', string $name = 'Test User', ?int $exp = null, ?string $kid = null): string
+    {
+        $payload = [
+            'iss'   => "https://securetoken.google.com/{$this->projectId}",
+            'aud'   => $this->projectId,
+            'sub'   => $uid,
+            'email' => $email,
+            'name'  => $name,
+            'iat'   => time() - 10,
+            'exp'   => $exp ?? (time() + 3600),
+        ];
+
+        return JWT::encode($payload, $this->privateKeyPem, 'RS256', $kid ?? $this->kid);
+    }
+
+    public function test_request_sin_header_authorization_devuelve_401(): void
+    {
+        $response = $this->getJson('/ed/profile');
+        $response->assertStatus(401);
+        $response->assertJson(['error' => 'Token de autorización ausente.']);
+    }
+
+    public function test_token_mal_formado_devuelve_401(): void
+    {
+        $response = $this->withHeader('Authorization', 'Bearer token-mal-formado-123')
+            ->getJson('/ed/profile');
+
+        $response->assertStatus(401);
+        $response->assertJson(['error' => 'Token inválido.']);
+    }
+
+    public function test_token_con_firma_invalida_devuelve_401(): void
+    {
+        $openSslConfig = [
+            'digest_alg'       => 'sha256',
+            'private_key_bits' => 2048,
+            'private_key_type' => OPENSSL_KEYTYPE_RSA,
+        ];
+        if (file_exists('C:\lenguajes\php\extras\ssl\openssl.cnf')) {
+            $openSslConfig['config'] = 'C:\lenguajes\php\extras\ssl\openssl.cnf';
+        }
+
+        // Generar otra clave privada no coincidente con el cert
+        $resOther = openssl_pkey_new($openSslConfig);
+        openssl_pkey_export($resOther, $otherPrivateKey, null, $openSslConfig);
+
+        $payload = [
+            'iss' => "https://securetoken.google.com/{$this->projectId}",
+            'aud' => $this->projectId,
+            'sub' => 'uid-123',
+            'exp' => time() + 3600,
+        ];
+        $tokenInvalido = JWT::encode($payload, $otherPrivateKey, 'RS256', $this->kid);
+
+        $response = $this->withHeader('Authorization', "Bearer {$tokenInvalido}")
+            ->getJson('/ed/profile');
+
+        $response->assertStatus(401);
+    }
+
+    public function test_token_expirado_devuelve_401(): void
+    {
+        $tokenExpirado = $this->crearTokenValido('uid-123', exp: time() - 10);
+
+        $response = $this->withHeader('Authorization', "Bearer {$tokenExpirado}")
+            ->getJson('/ed/profile');
+
+        $response->assertStatus(401);
+    }
+
+    public function test_token_valido_en_get_profile_crea_y_resuelve_usuario_correcto(): void
+    {
+        $token = $this->crearTokenValido('uid-firebase-nuevo', 'nuevo@example.com', 'Juan Perez');
+
+        $response = $this->withHeader('Authorization', "Bearer {$token}")
+            ->getJson('/ed/profile');
+
+        $response->assertSuccessful();
+        $response->assertJsonPath('data.firebase_uid', 'uid-firebase-nuevo');
+        $response->assertJsonPath('data.email', 'nuevo@example.com');
+        $response->assertJsonPath('data.name', 'Juan Perez');
+
+        $this->assertDatabaseHas('users', [
+            'firebase_uid' => 'uid-firebase-nuevo',
+            'email'        => 'nuevo@example.com',
+        ]);
+    }
+
+    public function test_post_pedido_crear_sin_token_devuelve_401(): void
+    {
+        $response = $this->postJson('/ed/pedido/crear', [
+            'productos' => [['producto_id' => 1, 'cantidad' => 1]],
+        ]);
+
+        $response->assertStatus(401);
+    }
+
+    public function test_token_valido_sin_usuario_local_devuelve_401_en_endpoints_protegidos_salvo_get_profile(): void
+    {
+        $token = $this->crearTokenValido('uid-sin-user-local');
+
+        // GET /profile SÍ debe funcionar (crea el usuario)
+        $respProfile = $this->withHeader('Authorization', "Bearer {$token}")
+            ->getJson('/ed/profile');
+        $respProfile->assertSuccessful();
+
+        // Para otro UID sin usuario local:
+        $tokenDesconocido = $this->crearTokenValido('uid-desconocido-completamente');
+
+        // POST /profile -> 401
+        $this->withHeader('Authorization', "Bearer {$tokenDesconocido}")
+            ->postJson('/ed/profile', ['name' => 'Otro'])
+            ->assertStatus(401);
+
+        // GET /carrito -> 401
+        $this->withHeader('Authorization', "Bearer {$tokenDesconocido}")
+            ->getJson('/ed/carrito')
+            ->assertStatus(401);
+
+        // GET /wishlist -> 401
+        $this->withHeader('Authorization', "Bearer {$tokenDesconocido}")
+            ->getJson('/ed/wishlist')
+            ->assertStatus(401);
+
+        // GET /mis-pedidos -> 401
+        $this->withHeader('Authorization', "Bearer {$tokenDesconocido}")
+            ->getJson('/ed/mis-pedidos')
+            ->assertStatus(401);
+    }
+
+    public function test_aislamiento_de_datos_entre_dos_usuarios(): void
+    {
+        $userA = User::create([
+            'name'         => 'Usuario A',
+            'email'        => 'usera@example.com',
+            'firebase_uid' => 'uid-user-a',
+            'password'     => bcrypt('secret'),
+        ]);
+
+        $userB = User::create([
+            'name'         => 'Usuario B',
+            'email'        => 'userb@example.com',
+            'firebase_uid' => 'uid-user-b',
+            'password'     => bcrypt('secret'),
+        ]);
+
+        $producto = Producto::create([
+            'nombre'         => 'Juego Test',
+            'descripcion'    => 'Desc',
+            'precioUnitario' => 1000,
+            'stock'          => 10,
+        ]);
+
+        // Carrito de B
+        Carrito::create(['user_id' => $userB->id, 'firebase_uid' => $userB->firebase_uid, 'producto_id' => $producto->id, 'cantidad' => 2]);
+        // Wishlist de B
+        Wishlist::create(['user_id' => $userB->id, 'firebase_uid' => $userB->firebase_uid, 'producto_id' => $producto->id]);
+        // Pedido de B
+        Pedido::create(['firebase_uid' => $userB->firebase_uid, 'estado' => 'pagado', 'total' => 1000, 'expira_at' => now()->addHours(72)]);
+
+        $tokenA = $this->crearTokenValido($userA->firebase_uid, $userA->email, $userA->name);
+
+        // Usuario A consulta perfil -> ve sus datos, no los de B
+        $respProfile = $this->withHeader('Authorization', "Bearer {$tokenA}")
+            ->getJson('/ed/profile');
+        $respProfile->assertStatus(200);
+        $respProfile->assertJsonPath('data.firebase_uid', 'uid-user-a');
+
+        // Usuario A consulta carrito -> vacío (0 elementos)
+        $respCart = $this->withHeader('Authorization', "Bearer {$tokenA}")
+            ->getJson('/ed/carrito');
+        $respCart->assertStatus(200);
+        $respCart->assertJsonCount(0);
+
+        // Usuario A consulta wishlist -> vacío
+        $respWish = $this->withHeader('Authorization', "Bearer {$tokenA}")
+            ->getJson('/ed/wishlist');
+        $respWish->assertStatus(200);
+        $respWish->assertJsonCount(0);
+
+        // Usuario A consulta mis-pedidos -> vacío
+        $respOrders = $this->withHeader('Authorization', "Bearer {$tokenA}")
+            ->getJson('/ed/mis-pedidos');
+        $respOrders->assertStatus(200);
+        $respOrders->assertJsonCount(0);
+    }
+
+    public function test_kid_no_encontrado_en_cache_invalida_cache_y_reintenta_una_vez(): void
+    {
+        // Cachear inicialmente claves sin el kid nuevo
+        Cache::put('firebase_public_keys', ['old-kid' => $this->certPem], 3600);
+
+        // Al pedir con 'nuevo-kid', Http::fake devolverá el certPem con el kid 'nuevo-kid'
+        $this->mockGoogleKeys(['nuevo-kid' => $this->certPem]);
+
+        $token = $this->crearTokenValido('uid-123', kid: 'nuevo-kid');
+
+        $response = $this->withHeader('Authorization', "Bearer {$token}")
+            ->getJson('/ed/profile');
+
+        $response->assertSuccessful();
+
+        // Si el kid sigue sin estar disponible tras la recarga:
+        $this->mockGoogleKeys(['otro-kid' => $this->certPem]);
+
+        $tokenInexistente = $this->crearTokenValido('uid-123', kid: 'kid-desconocido');
+
+        $response2 = $this->withHeader('Authorization', "Bearer {$tokenInexistente}")
+            ->getJson('/ed/profile');
+
+        $response2->assertStatus(401);
+    }
+}

--- a/tests/Feature/VerificarTokenFirebaseTest.php
+++ b/tests/Feature/VerificarTokenFirebaseTest.php
@@ -270,4 +270,17 @@ class VerificarTokenFirebaseTest extends TestCase
 
         $response2->assertStatus(401);
     }
+
+    public function test_migraciones_carrito_y_wishlist_crean_columna_user_id_e_indices_unicos(): void
+    {
+        $this->assertTrue(\Illuminate\Support\Facades\Schema::hasColumn('carrito', 'user_id'));
+        $this->assertTrue(\Illuminate\Support\Facades\Schema::hasColumn('wishlist', 'user_id'));
+
+        $indexes = \Illuminate\Support\Facades\DB::select("SELECT name, sql FROM sqlite_master WHERE type='index' AND name LIKE '%user_id_producto_id_unique%'");
+        $this->assertCount(2, $indexes);
+
+        foreach ($indexes as $index) {
+            $this->assertStringContainsString('user_id IS NOT NULL', $index->sql);
+        }
+    }
 }


### PR DESCRIPTION
## Resumen de cambios

- **Librería JWT:** Instalada `firebase/php-jwt` v6.11.1.
- **Configuración:** Creado `config/firebase.php` y variables `FIREBASE_PROJECT_ID` en `.env.example` y `phpunit.xml`.
- **Middlewares de autenticación:**
  - `VerificarTokenFirebase`: Valida firma RS256 de Google y claims `iss`, `aud`, `exp`. Usa `Cache::lock()` (check-lock-check) para evitar thundering herd al descargar certificados X.509 de Google.
  - `RequerirUsuarioLocal`: Resuelve `User` por `firebase_uid` para `$request->user()`. Retorna 401 si no existe.
- **Rutas de API (`routes/api.php`):**
  - `GET /profile` utiliza únicamente `firebase.token` (tolera registro implícito vía `firstOrCreate`).
  - `POST /profile`, `POST /pedido/crear`, `GET /mis-pedidos`, `/carrito` y `/wishlist` utilizan `['firebase.token', 'firebase.user']`.
- **Limpieza de controladores:** Eliminadas todas las lecturas descontinuadas de cabeceras `X-Firebase-UID`, `X-User-Email` y `X-User-Name`.
- **Migraciones y Modelos DB:**
  - Agregada columna `user_id` (FK nullable a `users.id`) en `carrito` y `wishlist` con backfill automático.
  - Reemplazados los índices únicos por índices parciales `WHERE user_id IS NOT NULL`.
- **Resource de API:** Creado `UserProfileResource` para estandarizar las respuestas de perfil.
- **Tests:** Suite `VerificarTokenFirebaseTest` (9 casos) + test de esquema y migración de índices. Reescrito `PedidoControllerTest` para usar tokens JWT firmados con RSA efímero. Total: 87 tests pasando (266 aserciones).

## ORDEN DE DESPLIEGUE

1. `php artisan migrate` contra la base
2. Verificar: `SELECT count(*) FROM carrito WHERE user_id IS NOT NULL`
3. Cargar `FIREBASE_PROJECT_ID` en las variables de Vercel
4. Recién ahí, deploy del código

> Sin el paso 3, el middleware falla cerrado y TODOS los endpoints autenticados devuelven 401.

## Salida de --testdox

```text
Buscar Productos Api (Tests\Feature\Filtros\BuscarProductosApi)
 ✔ Q con termino existente devuelve solo coincidencias
 ✔ Q vacio no filtra
 ✔ Q y categoria no devuelve productos de otra categoria
 ✔ Parametros invalidos devuelven 422
 ✔ Q con script devuelve 200
 ✔ Meta y links conservan ambos filtros
 ✔ Orden precio
 ✔ N plus 1 queries

Categorias Multiples (Tests\Feature\Hito2\CategoriasMultiples)
 ✔ Un producto con dos categorias aparece al filtrar por cualquiera
 ✔ Filtrar por dos categorias devuelve productos de ambas sin duplicados
 ✔ Un producto sin categorias aparece en el listado general
 ✔ Categoria inexistente devuelve 422
 ✔ Parametro viejo categoria id sigue funcionando
 ✔ Q combinado con categorias no trae productos de otras categorias
 ✔ N plus 1 queries mantenido

Categorias Panel (Tests\Feature\Hito2\CategoriasPanel)
 ✔ Get productos renderiza 200 y no contiene directivas blade literales
 ✔ Producto con dos categorias muestra ambas en el listado
 ✔ Producto sin categorias no rompe el listado
 ✔ Get subcategorias renderiza el boton de eliminar en cada fila
 ✔ Get producto edit trae las categorias del producto preseleccionadas
 ✔ Borrar categoria desde el panel devuelve exito y no borra productos
 ✔ Borrar subcategoria desde el panel devuelve exito
 ✔ Crear producto desde el panel con dos categorias las guarda ambas
 ✔ Crear producto desde el panel sin categorias funciona
 ✔ Editar producto cambiando solo el nombre mantiene sus categorias
 ✔ Editar producto quitando una categoria las sincroniza
 ✔ N plus 1 queries listado admin

Eliminar Sin Afectar Productos (Tests\Feature\Hito2\EliminarSinAfectarProductos)
 ✔ Borrar una categoria con productos no borra ningun producto
 ✔ Productos quedan con una categoria menos y siguen listandose
 ✔ Borrar una subcategoria no borra el producto
 ✔ Borrar un producto limpia ambos pivotes

Example (Tests\Unit\Example)
 ✔ That true is true

Liberar Pedidos Vencidos (Tests\Feature\LiberarPedidosVencidos)
 ✔ Command cancels expired pending order without mercado pago id
 ✔ Command does not cancel expired pending order with valid pending payment in mercado pago
 ✔ Command cancels expired pending order with expired payment in mercado pago
 ✔ Command cancels legacy pending order older than 96 hours
 ✔ Command does not cancel legacy pending order under 96 hours
 ✔ Command run twice does not restore stock twice
 ✔ Command does not touch paid or cancelled orders

Listado Url Sesion (Tests\Feature\Filtros\ListadoUrlSesion)
 ✔ Guarda url en sesion para productos
 ✔ Guarda url en sesion para categorias
 ✔ Guarda url en sesion para subcategorias
 ✔ Guarda url en sesion para pedidos
 ✔ Vista edicion renderiza enlace vuelta correcto

Pedido Admin Filtros (Tests\Feature\Filtros\PedidoAdminFiltros)
 ✔ Filtro total min abc no produce 500

Pedido Controller (Tests\Feature\PedidoController)
 ✔ Creating order with quantity exceeding stock fails with 409
 ✔ Concurrent orders on last item one succeeds other fails
 ✔ Order creation with web session but no firebase token returns 401

Pivot Categorias (Tests\Feature\Hito2\PivotCategorias)
 ✔ Un producto puede asociarse a varias categorias
 ✔ No se puede duplicar el mismo par producto categoria
 ✔ Borrar un producto elimina sus filas del pivot
 ✔ Borrar una categoria elimina sus filas del pivot pero no borra los productos
 ✔ La relacion categorias devuelve lo esperado

Producto Admin Filtros (Tests\Feature\Filtros\ProductoAdminFiltros)
 ✔ Filtro stock exacto
 ✔ Filtro stock abc no produce 500
 ✔ Filtro por categoria no trae parecidos
 ✔ Action del form no contiene http

Producto Sin Categoria (Tests\Feature\Hito2\ProductoSinCategoria)
 ✔ Se puede crear un producto sin categorias
 ✔ Se puede crear un producto sin imagenes
 ✔ Primera imagen devuelve la url de stock cuando no hay imagenes
 ✔ El resource devuelve categorias array vacio nunca null

Subcategoria Deletion (Tests\Feature\Hito2\SubcategoriaDeletion)
 ✔ Escenario a borrar subcategoria sin productos
 ✔ Escenario b borrar subcategoria con productos
 ✔ Escenario c borrar categoria sin productos
 ✔ Escenario d borrar categoria con subcategorias y productos
 ✔ Producto con dos subcategorias se borra una y queda con una
 ✔ Borrar categoria con tres subcategorias las tres desaparecen y productos subsisten
 ✔ Verificar fk producto subcategoria en esquema

Verificar Token Firebase (Tests\Feature\VerificarTokenFirebase)
 ✔ Request sin header authorization devuelve 401
 ✔ Token mal formado devuelve 401
 ✔ Token con firma invalida devuelve 401
 ✔ Token expirado devuelve 401
 ✔ Token valido en get profile crea y resuelve usuario correcto
 ✔ Post pedido crear sin token devuelve 401
 ✔ Token valido sin usuario local devuelve 401 en endpoints protegidos salvo get profile
 ✔ Aislamiento de datos entre dos usuarios
 ✔ Kid no encontrado en cache invalida cache y reintenta una vez
 ✔ Migraciones carrito y wishlist crean columna user id e indices unicos

Webhook (Tests\Feature\Webhook)
 ✔ Webhook fails without signature header
 ✔ Webhook fails with invalid signature header
 ✔ Webhook updates order to paid on approved status
 ✔ Webhook restores stock on terminal failure status
 ✔ Webhook restores stock only once on duplicate terminal failure events
 ✔ Webhook does not modify stock when already paid order receives approved again
 ✔ Webhook pending does not revert cancelled order
 ✔ Webhook pending does not revert paid order
 ✔ Webhook refunded transitions paid order to cancelled and restores stock

Tests: 87 passed (266 assertions)
```
