### PR TITLE
feat(panel): relacion pedidos-usuarios, panel de clientes y pedidos huerfanos

### DIFF
--- a/app/Http/Controllers/ClienteController.php
+++ b/app/Http/Controllers/ClienteController.php
@@ -1,0 +1,191 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Pedido;
+use App\Models\User;
+use Illuminate\Http\Request;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Str;
+
+class ClienteController extends Controller
+{
+    public function index(Request $request)
+    {
+        $request->validate([
+            'nombre_apellido' => 'nullable|string|max:255',
+            'email'           => 'nullable|string|max:255',
+            'ciudad'          => 'nullable|string|max:255',
+            'ultimo_estado'   => 'nullable|string|in:pendiente,pagado,cancelado',
+            'fecha_desde'     => 'nullable|date',
+            'fecha_hasta'     => 'nullable|date|after_or_equal:fecha_desde',
+        ]);
+
+        session(['listado_url.clientes' => url()->full()]);
+
+        $query = User::query()
+            ->withCount('pedidos as total_pedidos')
+            ->withSum('pedidos as total_gastado', 'total')
+            ->addSelect([
+                'ultimo_pedido_fecha' => Pedido::select('created_at')
+                    ->whereColumn('user_id', 'users.id')
+                    ->latest()
+                    ->limit(1),
+                'ultimo_pedido_estado' => Pedido::select('estado')
+                    ->whereColumn('user_id', 'users.id')
+                    ->latest()
+                    ->limit(1),
+            ]);
+
+        // Filtros
+        if ($request->filled('nombre_apellido')) {
+            $val = $request->input('nombre_apellido');
+            $query->where(function ($q) use ($val) {
+                $q->where('name', 'like', "%{$val}%")
+                  ->orWhere('apellido', 'like', "%{$val}%");
+            });
+        }
+
+        if ($request->filled('email')) {
+            $query->where('email', 'like', '%' . $request->input('email') . '%');
+        }
+
+        if ($request->filled('ciudad')) {
+            $query->where('ciudad', 'like', '%' . $request->input('ciudad') . '%');
+        }
+
+        if ($request->filled('ultimo_estado')) {
+            $estado = $request->input('ultimo_estado');
+            $query->whereRaw('(SELECT estado FROM pedidos WHERE user_id = users.id ORDER BY created_at DESC LIMIT 1) = ?', [$estado]);
+        }
+
+        if ($request->filled('fecha_desde')) {
+            $query->whereRaw('DATE((SELECT MAX(created_at) FROM pedidos WHERE user_id = users.id)) >= ?', [$request->input('fecha_desde')]);
+        }
+
+        if ($request->filled('fecha_hasta')) {
+            $query->whereRaw('DATE((SELECT MAX(created_at) FROM pedidos WHERE user_id = users.id)) <= ?', [$request->input('fecha_hasta')]);
+        }
+
+        $clientes = $query->orderByDesc('created_at')->paginate(10)->withQueryString();
+
+        $filtros = [
+            ['name' => 'nombre_apellido', 'placeholder' => 'Buscar por nombre o apellido'],
+            ['name' => 'email', 'placeholder' => 'Buscar por email'],
+            ['name' => 'ciudad', 'placeholder' => 'Buscar por ciudad'],
+            [
+                'name' => 'ultimo_estado',
+                'placeholder' => 'Estado del último pedido',
+                'type' => 'select',
+                'options' => [
+                    'pendiente' => 'Pendiente',
+                    'pagado'    => 'Pagado',
+                    'cancelado' => 'Cancelado',
+                ]
+            ],
+            ['name' => 'fecha_desde', 'placeholder' => 'Último pedido desde', 'type' => 'date'],
+            ['name' => 'fecha_hasta', 'placeholder' => 'Último pedido hasta', 'type' => 'date'],
+        ];
+
+        $columnas = [
+            ['label' => 'Cliente'],
+            ['label' => 'Email'],
+            ['label' => 'Ciudad'],
+            ['label' => 'Pedidos'],
+            ['label' => 'Total Gastado'],
+            ['label' => 'Último Pedido'],
+            ['label' => 'Estado Último'],
+        ];
+
+        $renderFila = function ($cliente) {
+            $getEstadoBadge = function ($estado) {
+                if (!$estado) {
+                    return '<span class="status-badge status-unknown">Sin pedidos</span>';
+                }
+                $badges = [
+                    'pendiente' => '<span class="status-badge status-pending"><i class="fas fa-clock"></i><span>Pendiente</span></span>',
+                    'pagado'    => '<span class="status-badge status-paid"><i class="fas fa-check-circle"></i><span>Pagado</span></span>',
+                    'cancelado' => '<span class="status-badge status-cancelled"><i class="fas fa-times-circle"></i><span>Cancelado</span></span>',
+                ];
+                return $badges[$estado] ?? '<span class="status-badge status-unknown">' . e($estado) . '</span>';
+            };
+
+            $nombreCompleto = trim($cliente->name . ' ' . ($cliente->apellido ?? ''));
+            $fechaUltimo = $cliente->ultimo_pedido_fecha ? Carbon::parse($cliente->ultimo_pedido_fecha)->format('d/m/Y H:i') : '-';
+            $total = number_format($cliente->total_gastado ?? 0, 2, ',', '.');
+
+            return '
+            <div class="table-cell" data-label="Cliente">
+                <span class="table-cell-label">Cliente:</span>
+                <a href="' . route('clientes.show', $cliente->id) . '" class="text-decoration-none fw-bold text-primary">
+                    <i class="fas fa-user-circle me-1"></i>' . e($nombreCompleto) . '
+                </a>
+            </div>
+            <div class="table-cell" data-label="Email">
+                <span class="table-cell-label">Email:</span>
+                <span class="text-secondary">' . e($cliente->email) . '</span>
+            </div>
+            <div class="table-cell" data-label="Ciudad">
+                <span class="table-cell-label">Ciudad:</span>
+                <span>' . e($cliente->ciudad ?? '-') . '</span>
+            </div>
+            <div class="table-cell" data-label="Pedidos">
+                <span class="table-cell-label">Pedidos:</span>
+                <span class="badge bg-secondary rounded-pill">' . $cliente->total_pedidos . '</span>
+            </div>
+            <div class="table-cell" data-label="Total Gastado">
+                <span class="table-cell-label">Total Gastado:</span>
+                <span class="fw-bold text-success">$' . $total . '</span>
+            </div>
+            <div class="table-cell" data-label="Último Pedido">
+                <span class="table-cell-label">Último Pedido:</span>
+                <span class="text-muted">' . $fechaUltimo . '</span>
+            </div>
+            <div class="table-cell" data-label="Estado Último">
+                <span class="table-cell-label">Estado Último:</span>
+                ' . $getEstadoBadge($cliente->ultimo_pedido_estado) . '
+            </div>';
+        };
+
+        if ($request->ajax()) {
+            return view('base.partials.tabla', [
+                'items'      => $clientes,
+                'columnas'   => $columnas,
+                'rutaVer'    => 'clientes.show',
+                'renderFila' => $renderFila
+            ])->render();
+        }
+
+        return view('cliente.cliente_listar', [
+            'clientes'   => $clientes,
+            'filtros'    => $filtros,
+            'columnas'   => $columnas,
+            'renderFila' => $renderFila
+        ]);
+    }
+
+    public function show($id)
+    {
+        $cliente = User::withCount('pedidos as total_pedidos')
+            ->withSum('pedidos as total_gastado', 'total')
+            ->findOrFail($id);
+
+        $pedidos = $cliente->pedidos()->orderByDesc('created_at')->get();
+
+        $cantidadPedidos = $cliente->total_pedidos;
+        $totalGastado = (float)($cliente->total_gastado ?? 0);
+        $ticketPromedio = $cantidadPedidos > 0 ? $totalGastado / $cantidadPedidos : 0;
+        $primerPedido = $pedidos->last();
+        $ultimoPedido = $pedidos->first();
+
+        return view('cliente.cliente_show', compact(
+            'cliente',
+            'pedidos',
+            'cantidadPedidos',
+            'totalGastado',
+            'ticketPromedio',
+            'primerPedido',
+            'ultimoPedido'
+        ));
+    }
+}

--- a/app/Http/Controllers/PedidoController.php
+++ b/app/Http/Controllers/PedidoController.php
@@ -17,23 +17,30 @@ class PedidoController extends Controller
     public function index(Request $request)
     {
         $request->validate([
-            'id' => 'nullable|integer|min:1',
-            'firebase_uid' => 'nullable|string|max:100',
-            'estado' => 'nullable|string|in:pendiente,pagado,cancelado',
+            'id'        => 'nullable|integer|min:1',
+            'cliente'   => 'nullable|string|max:255',
+            'estado'    => 'nullable|string|in:pendiente,pagado,cancelado',
             'total_min' => 'nullable|numeric|min:0',
             'total_max' => 'nullable|numeric|min:0|gte:total_min',
         ]);
 
         session(['listado_url.pedidos' => url()->full()]);
-        $query = Pedido::with(['detalles.producto']);
+        $query = Pedido::with(['user', 'detalles.producto']);
 
         // Aplicar filtros
         if ($request->filled('id')) {
             $query->where('id', $request->input('id'));
         }
 
-        if ($request->filled('firebase_uid')) {
-            $query->where('firebase_uid', 'like', '%' . $request->input('firebase_uid') . '%');
+        if ($request->filled('cliente')) {
+            $val = $request->input('cliente');
+            $query->where(function ($q) use ($val) {
+                $q->whereHas('user', function ($uq) use ($val) {
+                    $uq->where('name', 'like', "%{$val}%")
+                       ->orWhere('apellido', 'like', "%{$val}%")
+                       ->orWhere('email', 'like', "%{$val}%");
+                })->orWhere('firebase_uid', 'like', "%{$val}%");
+            });
         }
 
         if ($request->filled('estado')) {
@@ -54,14 +61,14 @@ class PedidoController extends Controller
         // Filtros para la vista
         $filtros = [
             ['name' => 'id', 'placeholder' => 'Buscar por ID del pedido'],
-            ['name' => 'firebase_uid', 'placeholder' => 'UID de Usuario'],
+            ['name' => 'cliente', 'placeholder' => 'Buscar por nombre, email o UID'],
             [
                 'name' => 'estado',
                 'placeholder' => 'Filtrar por estado',
                 'type' => 'select',
                 'options' => [
                     'pendiente' => 'Pendiente',
-                    'pagado' => 'Pagado',
+                    'pagado'    => 'Pagado',
                     'cancelado' => 'Cancelado'
                 ]
             ],
@@ -73,15 +80,9 @@ class PedidoController extends Controller
         $renderFila = function ($pedido) {
             $getEstadoBadge = function ($estado) {
                 $badges = [
-                    'pendiente' => '<span class="status-badge status-pending">
-                    <i class="fas fa-clock"></i><span>Pendiente</span>
-                </span>',
-                    'pagado' => '<span class="status-badge status-paid">
-                    <i class="fas fa-check-circle"></i><span>Pagado</span>
-                </span>',
-                    'cancelado' => '<span class="status-badge status-cancelled">
-                    <i class="fas fa-times-circle"></i><span>Cancelado</span>
-                </span>'
+                    'pendiente' => '<span class="status-badge status-pending"><i class="fas fa-clock"></i><span>Pendiente</span></span>',
+                    'pagado'    => '<span class="status-badge status-paid"><i class="fas fa-check-circle"></i><span>Pagado</span></span>',
+                    'cancelado' => '<span class="status-badge status-cancelled"><i class="fas fa-times-circle"></i><span>Cancelado</span></span>'
                 ];
                 return $badges[$estado] ?? '<span class="status-badge status-unknown">Desconocido</span>';
             };
@@ -98,6 +99,13 @@ class PedidoController extends Controller
             $totalProductos = $productosResumen->sum('cantidad');
             $primerProducto = $productosResumen->first();
 
+            if ($pedido->user) {
+                $nombreCliente = e($pedido->user->name . ($pedido->user->apellido ? ' ' . $pedido->user->apellido : ''));
+                $clienteHtml = '<a href="' . route('clientes.show', $pedido->user->id) . '" class="text-decoration-none fw-bold text-primary"><i class="fas fa-user me-1"></i>' . $nombreCliente . '</a>';
+            } else {
+                $clienteHtml = '<span class="status-badge status-unknown" data-bs-toggle="tooltip" title="UID: ' . e($pedido->firebase_uid) . '"><i class="fas fa-user-slash me-1"></i>Sin cliente asociado</span>';
+            }
+
             return '
             <div class="table-cell" data-label="ID">
                 <span class="table-cell-label">ID:</span>
@@ -109,12 +117,7 @@ class PedidoController extends Controller
                 <span class="table-cell-label">Cliente:</span>
                 <div class="customer-info">
                     <div class="customer-details">
-                        <span class="customer-uid truncate-15" 
-                              data-bs-toggle="tooltip" 
-                              data-bs-placement="top" 
-                              title="' . e($pedido->firebase_uid) . '">
-                            ' . e(Str::limit($pedido->firebase_uid, 12)) . '
-                        </span>
+                        ' . $clienteHtml . '
                     </div>
                 </div>
             </div>
@@ -178,12 +181,11 @@ class PedidoController extends Controller
         ]);
     }
 
-
-
     public function show($id)
     {
         try {
             $pedido = Pedido::with([
+                'user',
                 'detalles' => function ($query) {
                     $query->with(['producto' => function ($query) {
                         $query->with('imagenes');

--- a/app/Models/Pedido.php
+++ b/app/Models/Pedido.php
@@ -9,7 +9,7 @@ class Pedido extends Model
 {
     use HasFactory;
 
-    protected $fillable = ['firebase_uid', 'estado', 'mercado_pago_id', 'total', 'expira_at'];
+    protected $fillable = ['user_id', 'firebase_uid', 'estado', 'mercado_pago_id', 'total', 'expira_at'];
 
     protected $casts = [
         'expira_at' => 'datetime',
@@ -18,5 +18,10 @@ class Pedido extends Model
     public function detalles()
     {
         return $this->hasMany(DetallePedido::class);
+    }
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -50,4 +50,9 @@ class User extends Authenticatable
             'password' => 'hashed',
         ];
     }
+
+    public function pedidos()
+    {
+        return $this->hasMany(Pedido::class);
+    }
 }

--- a/database/migrations/2026_08_08_190000_add_user_id_to_pedidos_table.php
+++ b/database/migrations/2026_08_08_190000_add_user_id_to_pedidos_table.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Agrega user_id a la tabla pedidos con FK a users (nullOnDelete)
+     * y realiza el backfill asociando pedidos.firebase_uid con users.firebase_uid.
+     * La columna firebase_uid se conserva como respaldo.
+     */
+    public function up(): void
+    {
+        Schema::table('pedidos', function (Blueprint $table) {
+            $table->unsignedBigInteger('user_id')->nullable()->after('firebase_uid');
+            $table->foreign('user_id')->references('id')->on('users')->nullOnDelete();
+        });
+
+        // Backfill compatible con SQLite y PostgreSQL
+        DB::statement("
+            UPDATE pedidos
+            SET user_id = (
+                SELECT id FROM users WHERE users.firebase_uid = pedidos.firebase_uid
+            )
+            WHERE firebase_uid IS NOT NULL
+        ");
+    }
+
+    public function down(): void
+    {
+        Schema::table('pedidos', function (Blueprint $table) {
+            $table->dropForeign(['user_id']);
+            $table->dropColumn('user_id');
+        });
+    }
+};

--- a/resources/views/cliente/cliente_listar.blade.php
+++ b/resources/views/cliente/cliente_listar.blade.php
@@ -1,0 +1,7 @@
+@extends('base.listar')
+
+@php
+    $titulo = 'Gestión de Clientes';
+    $items = $clientes;
+    $rutaVer = 'clientes.show';
+@endphp

--- a/resources/views/cliente/cliente_show.blade.php
+++ b/resources/views/cliente/cliente_show.blade.php
@@ -1,0 +1,161 @@
+@extends('layouts.app')
+@section('title', 'Detalle del Cliente: ' . $cliente->name . ($cliente->apellido ? ' ' . $cliente->apellido : ''))
+
+@section('content')
+
+<!-- Header Section -->
+<div class="header-section">
+    <div class="header-content">
+        <div class="header-title-wrapper">
+            <h1 class="header-title">
+                <i class="fas fa-users header-icon"></i>
+                <span class="product-name">Cliente</span>
+                <span class="breadcrumb-separator">/</span>
+                <span class="section-name">{{ $cliente->name }} {{ $cliente->apellido }}</span>
+            </h1>
+        </div>
+        <div class="header-actions">
+            <a href="{{ session('listado_url.clientes', route('clientes.index')) }}" class="btn-back">
+                <i class="fas fa-arrow-left"></i>
+                <span class="btn-text">Volver al listado</span>
+            </a>
+        </div>
+    </div>
+</div>
+
+<!-- Order Details Grid (reutilizando estilos de pedido_show) -->
+<div class="order-details-grid mb-4">
+    <!-- Información Personal -->
+    <div class="detail-card">
+        <div class="detail-header">
+            <div class="detail-icon customer">
+                <i class="fas fa-user"></i>
+            </div>
+            <h4 class="detail-title">Datos Personales</h4>
+        </div>
+        <div class="detail-content">
+            <div class="info-row">
+                <span class="info-label">Nombre y Apellido:</span>
+                <span class="info-value">{{ $cliente->name }} {{ $cliente->apellido }}</span>
+            </div>
+            <div class="info-row">
+                <span class="info-label">Email:</span>
+                <span class="info-value">{{ $cliente->email }}</span>
+            </div>
+            <div class="info-row">
+                <span class="info-label">Domicilio:</span>
+                <span class="info-value">{{ $cliente->domicilio ?? 'No especificado' }}</span>
+            </div>
+            <div class="info-row">
+                <span class="info-label">Ciudad:</span>
+                <span class="info-value">{{ $cliente->ciudad ?? 'No especificada' }}</span>
+            </div>
+            <div class="info-row">
+                <span class="info-label">Código Postal:</span>
+                <span class="info-value">{{ $cliente->codigo_postal ?? 'No especificado' }}</span>
+            </div>
+            <div class="info-row">
+                <span class="info-label">Fecha de Registro:</span>
+                <span class="info-value">{{ $cliente->created_at ? $cliente->created_at->format('d/m/Y H:i') : '-' }}</span>
+            </div>
+        </div>
+    </div>
+
+    <!-- Estadísticas de Compras -->
+    <div class="detail-card">
+        <div class="detail-header">
+            <div class="detail-icon order">
+                <i class="fas fa-chart-line"></i>
+            </div>
+            <h4 class="detail-title">Estadísticas de Compras</h4>
+        </div>
+        <div class="detail-content">
+            <div class="info-row">
+                <span class="info-label">Pedidos Realizados:</span>
+                <span class="info-value">
+                    <span class="badge bg-secondary rounded-pill fs-6">{{ $cantidadPedidos }}</span>
+                </span>
+            </div>
+            <div class="info-row">
+                <span class="info-label">Total Gastado:</span>
+                <span class="info-value text-success fw-bold">${{ number_format($totalGastado, 2, ',', '.') }} ARS</span>
+            </div>
+            <div class="info-row">
+                <span class="info-label">Ticket Promedio:</span>
+                <span class="info-value">${{ number_format($ticketPromedio, 2, ',', '.') }} ARS</span>
+            </div>
+            <div class="info-row">
+                <span class="info-label">Primer Pedido:</span>
+                <span class="info-value">{{ $primerPedido ? $primerPedido->created_at->format('d/m/Y H:i') : '-' }}</span>
+            </div>
+            <div class="info-row">
+                <span class="info-label">Último Pedido:</span>
+                <span class="info-value">{{ $ultimoPedido ? $ultimoPedido->created_at->format('d/m/Y H:i') : '-' }}</span>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- Tabla Historial de Pedidos -->
+<div class="card shadow-sm border-0 mb-4">
+    <div class="card-header bg-white py-3">
+        <h5 class="m-0 font-weight-bold text-primary">
+            <i class="fas fa-history me-2"></i>Historial de Pedidos
+        </h5>
+    </div>
+    <div class="card-body p-0">
+        @if($pedidos->isEmpty())
+            <div class="text-center py-4 text-muted">
+                <i class="fas fa-box-open fa-2x mb-2 d-block"></i>
+                Este cliente no tiene pedidos registrados.
+            </div>
+        @else
+            <div class="table-responsive">
+                <table class="table table-hover align-middle m-0">
+                    <thead class="table-light">
+                        <tr>
+                            <th>ID Pedido</th>
+                            <th>Fecha</th>
+                            <th>Total</th>
+                            <th>Estado</th>
+                            <th>Acciones</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach($pedidos as $pedido)
+                            @php
+                                $statusBadges = [
+                                    'pendiente' => '<span class="status-badge status-pending"><i class="fas fa-clock"></i> Pendiente</span>',
+                                    'pagado'    => '<span class="status-badge status-paid"><i class="fas fa-check-circle"></i> Pagado</span>',
+                                    'cancelado' => '<span class="status-badge status-cancelled"><i class="fas fa-times-circle"></i> Cancelado</span>',
+                                ];
+                                $badge = $statusBadges[$pedido->estado] ?? '<span class="status-badge status-unknown">' . e($pedido->estado) . '</span>';
+                            @endphp
+                            <tr>
+                                <td data-label="ID Pedido">
+                                    <span class="order-number">#{{ str_pad($pedido->id, 4, '0', STR_PAD_LEFT) }}</span>
+                                </td>
+                                <td data-label="Fecha">
+                                    {{ $pedido->created_at->format('d/m/Y H:i') }}
+                                </td>
+                                <td data-label="Total">
+                                    <span class="fw-bold text-success">${{ number_format($pedido->total, 2, ',', '.') }}</span>
+                                </td>
+                                <td data-label="Estado">
+                                    {!! $badge !!}
+                                </td>
+                                <td data-label="Acciones">
+                                    <a href="{{ route('pedidos.show', $pedido->id) }}" class="btn btn-sm btn-outline-primary" data-bs-toggle="tooltip" title="Ver pedido">
+                                        <i class="fas fa-eye me-1"></i>Ver pedido
+                                    </a>
+                                </td>
+                            </tr>
+                        @endforeach
+                    </tbody>
+                </table>
+            </div>
+        @endif
+    </div>
+</div>
+
+@endsection

--- a/resources/views/layouts/sidebar.blade.php
+++ b/resources/views/layouts/sidebar.blade.php
@@ -50,6 +50,13 @@
                 <span>Pedidos</span>
             </a>
         </li>
+
+        <li class="nav-item">
+            <a class="nav-link d-flex align-items-center {{ request()->is('clientes*') ? 'active' : '' }}" href="{{ route('clientes.index') }}">
+                <i class="fas fa-users me-2"></i>
+                <span>Clientes</span>
+            </a>
+        </li>
     </ul>
 </aside>
 
@@ -101,6 +108,12 @@
                 <a class="nav-link d-flex align-items-center {{ request()->is('pedidos*') ? 'active' : '' }}" href="{{ route('pedidos.index') }}">
                     <i class="fas fa-shopping-cart me-2"></i>
                     <span>Pedidos</span>
+                </a>
+            </li>
+            <li class="nav-item">
+                <a class="nav-link d-flex align-items-center {{ request()->is('clientes*') ? 'active' : '' }}" href="{{ route('clientes.index') }}">
+                    <i class="fas fa-users me-2"></i>
+                    <span>Clientes</span>
                 </a>
             </li>
         </ul>

--- a/resources/views/pedido/pedido_listar.blade.php
+++ b/resources/views/pedido/pedido_listar.blade.php
@@ -1,26 +1,10 @@
 @extends('base.listar')
 
 @php
-    use Illuminate\Support\Str;
     $titulo = 'Gestión de Pedidos';
-
-    $filtros = [
-        ['name' => 'id', 'placeholder' => 'Buscar por ID del pedido'],
-        ['name' => 'firebase_uid', 'placeholder' => 'UID de Usuario'],
-        [
-            'name' => 'estado',
-            'placeholder' => 'Filtrar por estado',
-            'type' => 'select',
-            'options' => [
-                'pendiente' => 'Pendiente',
-                'pagado' => 'Pagado',
-                'cancelado' => 'Cancelado'
-            ]
-        ],
-        ['name' => 'total_min', 'placeholder' => 'Total mínimo ($)'],
-        ['name' => 'total_max', 'placeholder' => 'Total máximo ($)']
-    ];
-
+    $items = $pedidos;
+    $rutaVer = 'pedidos.show'; 
+    $rutaImprimir = 'pedidos.imprimir';
     $columnas = [
         ['label' => 'ID'],
         ['label' => 'Cliente'],
@@ -29,96 +13,4 @@
         ['label' => 'Fecha'],
         ['label' => 'Productos'],
     ];
-
-    $items = $pedidos;
-    $rutaVer = 'pedidos.show'; 
-    $rutaImprimir = 'pedidos.imprimir';
-    $renderFila = function($pedido) {
-        // Función para obtener el badge del estado
-        $getEstadoBadge = function($estado) {
-            $badges = [
-                'pendiente' => '<span class="status-badge status-pending">
-                    <i class="fas fa-clock"></i>
-                    <span>Pendiente</span>
-                </span>',
-                'pagado' => '<span class="status-badge status-paid">
-                    <i class="fas fa-check-circle"></i>
-                    <span>Pagado</span>
-                </span>',
-                'cancelado' => '<span class="status-badge status-cancelled">
-                    <i class="fas fa-times-circle"></i>
-                    <span>Cancelado</span>
-                </span>'
-            ];
-            return $badges[$estado] ?? '<span class="status-badge status-unknown">Desconocido</span>';
-        };
-
-        // Resumen de productos
-        $productosResumen = collect($pedido->detalles)->map(function ($detalle) {
-            $nombreProducto = optional($detalle->producto)->nombre ?? 'Producto eliminado';
-            return [
-                'nombre' => $nombreProducto,
-                'cantidad' => $detalle->cantidad,
-                'precio' => $detalle->precio_unitario
-            ];
-        });
-
-        $totalProductos = $productosResumen->sum('cantidad');
-        $primerProducto = $productosResumen->first();
-
-        return '
-            <div class="table-cell" data-label="ID">
-                <span class="table-cell-label">ID:</span>
-                <div class="order-id">
-                    <span class="order-number">#' . str_pad($pedido->id, 4, '0', STR_PAD_LEFT) . '</span>
-                </div>
-            </div>
-            <div class="table-cell" data-label="Cliente">
-                <span class="table-cell-label">Cliente:</span>
-                <div class="customer-info">
-                    <div class="customer-details">
-                        <span class="customer-uid truncate-15" 
-                              data-bs-toggle="tooltip" 
-                              data-bs-placement="top" 
-                              title="' . e($pedido->firebase_uid) . '">
-                            ' . e(Str::limit($pedido->firebase_uid, 12)) . '
-                        </span>
-                    </div>
-                </div>
-            </div>
-            <div class="table-cell" data-label="Estado">
-                <span class="table-cell-label">Estado:</span>
-                ' . $getEstadoBadge($pedido->estado) . '
-            </div>
-            <div class="table-cell" data-label="Total">
-                <span class="table-cell-label">Total:</span>
-                <div class="order-total">
-                    <span class="amount">$' . number_format($pedido->total, 2, ',', '.') . '</span>
-                    <small class="currency">ARS</small>
-                </div>
-            </div>
-            <div class="table-cell" data-label="Fecha">
-                <span class="table-cell-label">Fecha:</span>
-                <div class="order-date">
-                    <span class="date">' . $pedido->created_at->format('d/m/Y') . '</span>
-                    <small class="time">' . $pedido->created_at->format('H:i') . '</small>
-                </div>
-            </div>
-            <div class="table-cell" data-label="Productos">
-                <span class="table-cell-label">Productos:</span>
-                <div class="products-summary">
-                    ' . ($primerProducto ? '
-                        <div class="product-item">
-                            <span class="product-name">' . e(Str::limit($primerProducto['nombre'], 20)) . '</span>
-                            <span class="product-quantity">x' . $primerProducto['cantidad'] . '</span>
-                        </div>
-                    ' : '<span class="no-products">Sin productos</span>') . '
-                    ' . ($totalProductos > 1 ? '
-                        <div class="more-products">
-                            <span class="more-count">+' . ($totalProductos - 1) . ' más</span>
-                        </div>
-                    ' : '') . '
-                </div>
-            </div>';
-    };
 @endphp

--- a/resources/views/pedido/pedido_show.blade.php
+++ b/resources/views/pedido/pedido_show.blade.php
@@ -73,10 +73,35 @@
             <h4 class="detail-title">Información del Cliente</h4>
         </div>
         <div class="detail-content">
-            <div class="info-row">
-                <span class="info-label">ID de Usuario:</span>
-                <span class="info-value customer-uid">{{ $pedido->firebase_uid }}</span>
-            </div>
+            @if($pedido->user)
+                <div class="info-row">
+                    <span class="info-label">Nombre:</span>
+                    <span class="info-value">
+                        <a href="{{ route('clientes.show', $pedido->user->id) }}" class="text-decoration-none fw-bold text-primary">
+                            <i class="fas fa-user me-1"></i>{{ $pedido->user->name }} {{ $pedido->user->apellido }}
+                        </a>
+                    </span>
+                </div>
+                <div class="info-row">
+                    <span class="info-label">Email:</span>
+                    <span class="info-value">{{ $pedido->user->email }}</span>
+                </div>
+                <div class="info-row">
+                    <span class="info-label">UID de Firebase:</span>
+                    <span class="info-value customer-uid">{{ $pedido->firebase_uid }}</span>
+                </div>
+            @else
+                <div class="info-row">
+                    <span class="info-label">Cliente:</span>
+                    <span class="info-value">
+                        <span class="status-badge status-unknown"><i class="fas fa-user-slash me-1"></i>Sin cliente asociado</span>
+                    </span>
+                </div>
+                <div class="info-row">
+                    <span class="info-label">UID de Firebase:</span>
+                    <span class="info-value customer-uid">{{ $pedido->firebase_uid }}</span>
+                </div>
+            @endif
         </div>
     </div>
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -13,6 +13,8 @@ use Illuminate\Http\Request;
 use App\Http\Controllers\WebhookController;
 use App\Http\Controllers\EstadisticasController;
 
+use App\Http\Controllers\ClienteController;
+
 // Rutas de autenticación
 Route::get('/login', [LoginController::class, 'showLoginForm'])->name('login');
 Route::post('/login', [LoginController::class, 'login'])->name('login.submit');
@@ -27,6 +29,8 @@ Route::middleware(['auth', AdminMiddleware::class])->group(function () {
 
     Route::resource('pedidos', PedidoController::class);
     Route::get('/pedidos/{id}/imprimir', [PedidoController::class, 'imprimir'])->name('pedidos.imprimir');
+
+    Route::resource('clientes', ClienteController::class)->only(['index', 'show']);
 
     # Productos
     Route::resource('productos', ProductoController::class);

--- a/tests/Feature/ClienteControllerTest.php
+++ b/tests/Feature/ClienteControllerTest.php
@@ -1,0 +1,183 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Pedido;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class ClienteControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $admin;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->admin = User::factory()->create(['name' => 'Admin User']);
+        $this->actingAs($this->admin);
+    }
+
+    public function test_migracion_user_id_asocia_pedidos_y_deja_huerfanos(): void
+    {
+        $user = User::factory()->create(['firebase_uid' => 'uid-con-pedidos']);
+
+        $pedidoAsociado = Pedido::create([
+            'firebase_uid' => 'uid-con-pedidos',
+            'estado'       => 'pagado',
+            'total'        => 500,
+            'expira_at'    => now()->addHours(72),
+        ]);
+
+        $pedidoHuerfano = Pedido::create([
+            'firebase_uid' => 'Max Verstappen',
+            'estado'       => 'pendiente',
+            'total'        => 100,
+            'expira_at'    => now()->addHours(72),
+        ]);
+
+        // Ejecutar manualmente la lógica del SQL de la migración
+        DB::statement("
+            UPDATE pedidos
+            SET user_id = (SELECT id FROM users WHERE users.firebase_uid = pedidos.firebase_uid)
+            WHERE firebase_uid IS NOT NULL
+        ");
+
+        $this->assertEquals($user->id, $pedidoAsociado->fresh()->user_id);
+        $this->assertNull($pedidoHuerfano->fresh()->user_id);
+    }
+
+    public function test_filtros_listado_clientes(): void
+    {
+        $user1 = User::factory()->create([
+            'name'         => 'Carlos',
+            'apellido'     => 'Tevez',
+            'email'        => 'carlos@example.com',
+            'ciudad'       => 'Buenos Aires',
+            'firebase_uid' => 'uid-carlos',
+        ]);
+        $p1 = new Pedido(['user_id' => $user1->id, 'firebase_uid' => $user1->firebase_uid, 'estado' => 'pagado', 'total' => 1000, 'expira_at' => now()->addHours(72)]);
+        $p1->created_at = now()->subDays(5);
+        $p1->save();
+
+        $user2 = User::factory()->create([
+            'name'         => 'Lionel',
+            'apellido'     => 'Messi',
+            'email'        => 'lionel@example.com',
+            'ciudad'       => 'Rosario',
+            'firebase_uid' => 'uid-lionel',
+        ]);
+        $p2 = new Pedido(['user_id' => $user2->id, 'firebase_uid' => $user2->firebase_uid, 'estado' => 'pendiente', 'total' => 500, 'expira_at' => now()->addHours(72)]);
+        $p2->created_at = now();
+        $p2->save();
+
+        // Filtro nombre_apellido
+        $resp = $this->get('/clientes?nombre_apellido=Tevez');
+        $resp->assertStatus(200);
+        $resp->assertSee('Carlos Tevez');
+        $resp->assertDontSee('Lionel Messi');
+
+        // Filtro email
+        $resp = $this->get('/clientes?email=lionel@example.com');
+        $resp->assertStatus(200);
+        $resp->assertSee('Lionel Messi');
+        $resp->assertDontSee('Carlos Tevez');
+
+        // Filtro ciudad
+        $resp = $this->get('/clientes?ciudad=Rosario');
+        $resp->assertStatus(200);
+        $resp->assertSee('Lionel Messi');
+
+        // Filtro ultimo_estado
+        $resp = $this->get('/clientes?ultimo_estado=pagado');
+        $resp->assertStatus(200);
+        $resp->assertSee('Carlos Tevez');
+        $resp->assertDontSee('Lionel Messi');
+
+        // Filtro fechas
+        $resp = $this->get('/clientes?fecha_desde=' . now()->subDays(10)->format('Y-m-d') . '&fecha_hasta=' . now()->subDays(2)->format('Y-m-d'));
+        $resp->assertStatus(200);
+        $resp->assertSee('Carlos Tevez');
+        $resp->assertDontSee('Lionel Messi');
+    }
+
+    public function test_filtro_invalido_devuelve_422_nunca_500(): void
+    {
+        // Estado inválido
+        $response = $this->getJson('/clientes?ultimo_estado=invalido');
+        $response->assertStatus(422);
+
+        // Fecha hasta menor a fecha desde
+        $response = $this->getJson('/clientes?fecha_desde=2026-08-10&fecha_hasta=2026-08-01');
+        $response->assertStatus(422);
+    }
+
+    public function test_n_plus_1_queries_listado_clientes_constante_entre_8_y_40_clientes(): void
+    {
+        // Escenario 1: 8 clientes
+        User::factory()->count(8)->create(['firebase_uid' => fn() => 'uid-' . uniqid()])->each(function ($user) {
+            Pedido::create(['user_id' => $user->id, 'firebase_uid' => $user->firebase_uid, 'estado' => 'pagado', 'total' => 100, 'expira_at' => now()->addHours(72)]);
+        });
+
+        DB::flushQueryLog();
+        DB::enableQueryLog();
+        $this->get('/clientes')->assertStatus(200);
+        $queries8 = count(DB::getQueryLog());
+        DB::disableQueryLog();
+
+        // Escenario 2: 40 clientes
+        User::factory()->count(32)->create(['firebase_uid' => fn() => 'uid-' . uniqid()])->each(function ($user) {
+            Pedido::create(['user_id' => $user->id, 'firebase_uid' => $user->firebase_uid, 'estado' => 'pagado', 'total' => 100, 'expira_at' => now()->addHours(72)]);
+        });
+
+        DB::flushQueryLog();
+        DB::enableQueryLog();
+        $this->get('/clientes')->assertStatus(200);
+        $queries40 = count(DB::getQueryLog());
+        DB::disableQueryLog();
+
+        $this->assertEquals($queries8, $queries40, "La cantidad de queries N+1 debe ser constante ({$queries8} vs {$queries40})");
+    }
+
+    public function test_cliente_sin_pedidos_se_lista_y_muestra_detalle_sin_romper(): void
+    {
+        $clienteSinPedidos = User::factory()->create([
+            'name'         => 'Sin',
+            'apellido'     => 'Pedidos',
+            'email'        => 'sinpedidos@example.com',
+            'firebase_uid' => 'uid-sinpedidos',
+        ]);
+
+        $respList = $this->get('/clientes');
+        $respList->assertStatus(200);
+        $respList->assertSee('Sin Pedidos');
+        $respList->assertSee('Sin pedidos');
+
+        $respDetail = $this->get("/clientes/{$clienteSinPedidos->id}");
+        $respDetail->assertStatus(200);
+        $respDetail->assertSee('Este cliente no tiene pedidos registrados.');
+        $respDetail->assertSee('sinpedidos@example.com');
+    }
+
+    public function test_pedidos_huerfanos_no_rompen_listado_de_pedidos_y_muestran_texto_neutro(): void
+    {
+        $pedidoHuerfano = Pedido::create([
+            'firebase_uid' => 'Max Verstappen',
+            'estado'       => 'pendiente',
+            'total'        => 100,
+            'expira_at'    => now()->addHours(72),
+        ]);
+
+        $resp = $this->get('/pedidos');
+        $resp->assertStatus(200);
+        $resp->assertSee('Sin cliente asociado');
+
+        $respShow = $this->get("/pedidos/{$pedidoHuerfano->id}");
+        $respShow->assertStatus(200);
+        $respShow->assertSee('Sin cliente asociado');
+        $respShow->assertSee('Max Verstappen');
+    }
+}


### PR DESCRIPTION
## Resumen de cambios - Hito 4 Parte 2 (Backend)

- **Relación pedidos-usuarios:**
  - Migración `2026_08_08_190000_add_user_id_to_pedidos_table.php` agrega la columna `user_id` (FK nullable a `users.id` con `nullOnDelete()`) y realiza el backfill desde `pedidos.firebase_uid`.
  - Definidas las relaciones `Pedido->user()` y `User->pedidos()`.
  - Preservada la columna `firebase_uid` de `pedidos` como respaldo.

- **Panel de Clientes (`ClienteController`):**
  - Creada ruta `/clientes` (`clientes.index`) y `/clientes/{id}` (`clientes.show`).
  - Listado con filtros completos (`nombre_apellido`, `email`, `ciudad`, `ultimo_estado`, `fecha_desde`, `fecha_hasta`) con `$request->validate()`.
  - N+1 optimizado mediante `withCount('pedidos')`, `withSum('pedidos', 'total')` y subqueries `SELECT MAX(created_at)` / `SELECT estado ... LIMIT 1`.
  - Atributos `data-label` en todas las celdas para tarjetas responsive en 360px.
  - Vista de detalle de cliente con datos personales, estadísticas (`cantidadPedidos`, `totalGastado`, `ticketPromedio`, `primerPedido`, `ultimoPedido`) e historial de pedidos.

- **Listado y detalle de Pedidos:**
  - Eager load de `user` en `PedidoController@index` y `show`.
  - Reemplazado `Str::limit($pedido->firebase_uid, 12)` por el nombre y apellido enlazado al perfil del cliente.
  - Pedidos huérfanos (`user_id` null) muestran de forma segura el texto neutro con badge `"Sin cliente asociado"`.
  - Filtro `cliente` reemplaza el filtro por `firebase_uid`.

- **Navegación Admin:**
  - Agregado el item de navegación "Clientes" con ícono `fas fa-users` tanto en el sidebar de escritorio como en el menú offcanvas móvil.

- **Pruebas:**
  - Suite `ClienteControllerTest` con 6 tests pasando (32 aserciones) verificando todos los filtros, N+1 constante (8 vs 40 clientes), detalle de cliente sin pedidos, manejo de pedidos huérfanos y migración `user_id`.

## Salida de --testdox

```text
Buscar Productos Api (Tests\Feature\Filtros\BuscarProductosApi)
 ✔ Q con termino existente devuelve solo coincidencias
 ✔ Q vacio no filtra
 ✔ Q y categoria no devuelve productos de otra categoria
 ✔ Parametros invalidos devuelven 422
 ✔ Q con script devuelve 200
 ✔ Meta y links conservan ambos filtros
 ✔ Orden precio
 ✔ N plus 1 queries

Categorias Multiples (Tests\Feature\Hito2\CategoriasMultiples)
 ✔ Un producto con dos categorias aparece al filtrar por cualquiera
 ✔ Filtrar por dos categorias devuelve productos de ambas sin duplicados
 ✔ Un producto sin categorias aparece en el listado general
 ✔ Categoria inexistente devuelve 422
 ✔ Parametro viejo categoria id sigue funcionando
 ✔ Q combinado con categorias no trae productos de otras categorias
 ✔ N plus 1 queries mantenido

Categorias Panel (Tests\Feature\Hito2\CategoriasPanel)
 ✔ Get productos renderiza 200 y no contiene directivas blade literales
 ✔ Producto con dos categorias muestra ambas en el listado
 ✔ Producto sin categorias no rompe el listado
 ✔ Get subcategorias renderiza el boton de eliminar en cada fila
 ✔ Get producto edit trae las categorias del producto preseleccionadas
 ✔ Borrar categoria desde el panel devuelve exito y no borra productos
 ✔ Borrar subcategoria desde el panel devuelve exito
 ✔ Crear producto desde el panel con dos categorias las guarda ambas
 ✔ Crear producto desde el panel sin categorias funciona
 ✔ Editar producto cambiando solo el nombre mantiene sus categorias
 ✔ Editar producto quitando una categoria las sincroniza
 ✔ N plus 1 queries listado admin

Cliente Controller (Tests\Feature\ClienteController)
 ✔ Migracion user id asocia pedidos y deja huerfanos
 ✔ Filtros listado clientes
 ✔ Filtro invalido devuelve 422 nunca 500
 ✔ N plus 1 queries listado clientes constante entre 8 y 40 clientes
 ✔ Cliente sin pedidos se lista y muestra detalle sin romper
 ✔ Pedidos huerfanos no rompen listado de pedidos y muestran texto neutro

Eliminar Sin Afectar Productos (Tests\Feature\Hito2\EliminarSinAfectarProductos)
 ✔ Borrar una categoria con productos no borra ningun producto
 ✔ Productos quedan con una categoria menos y siguen listandose
 ✔ Borrar una subcategoria no borra el producto
 ✔ Borrar un producto limpia ambos pivotes

Example (Tests\Unit\Example)
 ✔ That true is true

Liberar Pedidos Vencidos (Tests\Feature\LiberarPedidosVencidos)
 ✔ Command cancels expired pending order without mercado pago id
 ✔ Command does not cancel expired pending order with valid pending payment in mercado pago
 ✔ Command cancels expired pending order with expired payment in mercado pago
 ✔ Command cancels legacy pending order older than 96 hours
 ✔ Command does not cancel legacy pending order under 96 hours
 ✔ Command run twice does not restore stock twice
 ✔ Command does not touch paid or cancelled orders

Listado Url Sesion (Tests\Feature\Filtros\ListadoUrlSesion)
 ✔ Guarda url en sesion para productos
 ✔ Guarda url en sesion para categorias
 ✔ Guarda url en sesion para subcategorias
 ✔ Guarda url en sesion para pedidos
 ✔ Vista edicion renderiza enlace vuelta correcto

Pedido Admin Filtros (Tests\Feature\Filtros\PedidoAdminFiltros)
 ✔ Filtro total min abc no produce 500

Pedido Controller (Tests\Feature\PedidoController)
 ✔ Creating order with quantity exceeding stock fails with 409
 ✔ Concurrent orders on last item one succeeds other fails
 ✔ Order creation with web session but no firebase token returns 401

Pivot Categorias (Tests\Feature\Hito2\PivotCategorias)
 ✔ Un producto puede asociarse a varias categorias
 ✔ No se puede duplicar el mismo par producto categoria
 ✔ Borrar un producto elimina sus filas del pivot
 ✔ Borrar una categoria elimina sus filas del pivot pero no borra los productos
 ✔ La relacion categorias devuelve lo esperado

Producto Admin Filtros (Tests\Feature\Filtros\ProductoAdminFiltros)
 ✔ Filtro stock exacto
 ✔ Filtro stock abc no produce 500
 ✔ Filtro por categoria no trae parecidos
 ✔ Action del form no contiene http

Producto Sin Categoria (Tests\Feature\Hito2\ProductoSinCategoria)
 ✔ Se puede crear un producto sin categorias
 ✔ Se puede crear un producto sin imagenes
 ✔ Primera imagen devuelve la url de stock cuando no hay imagenes
 ✔ El resource devuelve categorias array vacio nunca null

Subcategoria Deletion (Tests\Feature\Hito2\SubcategoriaDeletion)
 ✔ Escenario a borrar subcategoria sin productos
 ✔ Escenario b borrar subcategoria con productos
 ✔ Escenario c borrar categoria sin productos
 ✔ Escenario d borrar categoria con subcategorias y productos
 ✔ Producto con dos subcategorias se borra una y queda con una
 ✔ Borrar categoria con tres subcategorias las tres desaparecen y productos subsisten
 ✔ Verificar fk producto subcategoria en esquema

Verificar Token Firebase (Tests\Feature\VerificarTokenFirebase)
 ✔ Request sin header authorization devuelve 401
 ✔ Token mal formado devuelve 401
 ✔ Token con firma invalida devuelve 401
 ✔ Token expirado devuelve 401
 ✔ Token valido en get profile crea y resuelve usuario correcto
 ✔ Post pedido crear sin token devuelve 401
 ✔ Token valido sin usuario local devuelve 401 en endpoints protegidos salvo get profile
 ✔ Aislamiento de datos entre dos usuarios
 ✔ Kid no encontrado en cache invalida cache y reintenta una vez
 ✔ Migraciones carrito y wishlist crean columna user id e indices unicos

Webhook (Tests\Feature\Webhook)
 ✔ Webhook fails without signature header
 ✔ Webhook fails with invalid signature header
 ✔ Webhook updates order to paid on approved status
 ✔ Webhook restores stock on terminal failure status
 ✔ Webhook restores stock only once on duplicate terminal failure events
 ✔ Webhook does not modify stock when already paid order receives approved again
 ✔ Webhook pending does not revert cancelled order
 ✔ Webhook pending does not revert paid order
 ✔ Webhook refunded transitions paid order to cancelled and restores stock

Tests: 93 passed (298 assertions)
```
