### PR TITLE
fix(clientes): agregar desempate por id DESC en subqueries del ultimo pedido

### DIFF
--- a/app/Http/Controllers/ClienteController.php
+++ b/app/Http/Controllers/ClienteController.php
@@ -29,11 +29,13 @@ class ClienteController extends Controller
             ->addSelect([
                 'ultimo_pedido_fecha' => Pedido::select('created_at')
                     ->whereColumn('user_id', 'users.id')
-                    ->latest()
+                    ->orderByDesc('created_at')
+                    ->orderByDesc('id')
                     ->limit(1),
                 'ultimo_pedido_estado' => Pedido::select('estado')
                     ->whereColumn('user_id', 'users.id')
-                    ->latest()
+                    ->orderByDesc('created_at')
+                    ->orderByDesc('id')
                     ->limit(1),
             ]);
 
@@ -56,7 +58,7 @@ class ClienteController extends Controller
 
         if ($request->filled('ultimo_estado')) {
             $estado = $request->input('ultimo_estado');
-            $query->whereRaw('(SELECT estado FROM pedidos WHERE user_id = users.id ORDER BY created_at DESC LIMIT 1) = ?', [$estado]);
+            $query->whereRaw('(SELECT estado FROM pedidos WHERE user_id = users.id ORDER BY created_at DESC, id DESC LIMIT 1) = ?', [$estado]);
         }
 
         if ($request->filled('fecha_desde')) {

--- a/tests/Feature/ClienteControllerTest.php
+++ b/tests/Feature/ClienteControllerTest.php
@@ -180,4 +180,41 @@ class ClienteControllerTest extends TestCase
         $respShow->assertSee('Sin cliente asociado');
         $respShow->assertSee('Max Verstappen');
     }
+
+    public function test_desempate_ultimo_pedido_mismo_timestamp_id_mayor_prevalece(): void
+    {
+        $user = User::factory()->create([
+            'name'         => 'Empate',
+            'apellido'     => 'Tester',
+            'firebase_uid' => 'uid-empate',
+        ]);
+
+        $now = now()->subMinutes(10);
+
+        // Primer pedido (ID menor): estado 'pendiente'
+        $p1 = new Pedido(['user_id' => $user->id, 'firebase_uid' => $user->firebase_uid, 'estado' => 'pendiente', 'total' => 100, 'expira_at' => now()->addHours(72)]);
+        $p1->created_at = $now;
+        $p1->save();
+
+        // Segundo pedido (ID mayor): estado 'pagado', mismo created_at
+        $p2 = new Pedido(['user_id' => $user->id, 'firebase_uid' => $user->firebase_uid, 'estado' => 'pagado', 'total' => 200, 'expira_at' => now()->addHours(72)]);
+        $p2->created_at = $now;
+        $p2->save();
+
+        // El listado general debe mostrar 'pagado' (el de mayor ID)
+        $resp = $this->get('/clientes');
+        $resp->assertStatus(200);
+        $resp->assertSee('Empate Tester');
+        $resp->assertSee('Pagado');
+
+        // El filtro por ultimo_estado=pagado debe incluir a Empate Tester
+        $respPagado = $this->get('/clientes?ultimo_estado=pagado');
+        $respPagado->assertStatus(200);
+        $respPagado->assertSee('Empate Tester');
+
+        // El filtro por ultimo_estado=pendiente NO debe incluir a Empate Tester
+        $respPendiente = $this->get('/clientes?ultimo_estado=pendiente');
+        $respPendiente->assertStatus(200);
+        $respPendiente->assertDontSee('Empate Tester');
+    }
 }


### PR DESCRIPTION
Correccion del criterio de ordenamiento en subqueries de ultimo_pedido_fecha, ultimo_pedido_estado y filtro por ultimo_estado agregando 'created_at DESC, id DESC' para garantizar determinismo ante timestamps duplicados.