### PR TITLE
feat(pedidos): Snapshot de dirección, fix user_id y filtro por stock

### DIFF
--- a/app/Console/Commands/ReasociarUsuariosPedidos.php
+++ b/app/Console/Commands/ReasociarUsuariosPedidos.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+
+class ReasociarUsuariosPedidos extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'pedidos:reasociar-usuarios';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Completa el user_id de los pedidos existentes cruzando su firebase_uid con la tabla users';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(): int
+    {
+        $affected = DB::update("
+            UPDATE pedidos
+            SET user_id = (
+                SELECT id FROM users WHERE users.firebase_uid = pedidos.firebase_uid
+            )
+            WHERE user_id IS NULL
+              AND firebase_uid IS NOT NULL
+              AND firebase_uid NOT IN ('Max Verstappen', 'anonimo')
+        ");
+
+        $this->info("Reasociación completada. Pedidos actualizados: {$affected}");
+
+        return Command::SUCCESS;
+    }
+}

--- a/app/Http/Controllers/CarritoController.php
+++ b/app/Http/Controllers/CarritoController.php
@@ -44,10 +44,7 @@ class CarritoController extends Controller
 
         $item = Carrito::updateOrCreate(
             ['user_id' => $userId, 'producto_id' => $request->producto_id],
-            [
-                'firebase_uid' => $request->user()->firebase_uid,
-                'cantidad'     => $cantidad,
-            ]
+            ['cantidad' => $cantidad]
         );
 
         return response()->json($item);

--- a/app/Http/Controllers/CarritoController.php
+++ b/app/Http/Controllers/CarritoController.php
@@ -44,7 +44,10 @@ class CarritoController extends Controller
 
         $item = Carrito::updateOrCreate(
             ['user_id' => $userId, 'producto_id' => $request->producto_id],
-            ['cantidad' => $cantidad]
+            [
+                'firebase_uid' => $request->user()->firebase_uid,
+                'cantidad'     => $cantidad,
+            ]
         );
 
         return response()->json($item);

--- a/app/Http/Controllers/PedidoController.php
+++ b/app/Http/Controllers/PedidoController.php
@@ -271,9 +271,13 @@ class PedidoController extends Controller
     public function store(Request $request)
     {
         $request->validate([
-            'productos' => 'required|array|min:1',
+            'productos'               => 'required|array|min:1',
             'productos.*.producto_id' => 'required|exists:productos,id',
-            'productos.*.cantidad' => 'required|integer|min:1',
+            'productos.*.cantidad'    => 'required|integer|min:1',
+            'email'                   => 'nullable|email|max:255',
+            'codigo_postal'           => 'nullable|string|regex:/^\d{4}$/',
+            'domicilio'               => 'nullable|string|max:255',
+            'ciudad'                  => 'nullable|string|max:255',
         ]);
 
         $user = $request->user();
@@ -288,10 +292,15 @@ class PedidoController extends Controller
             $expiracion = now()->addHours(config('mercadopago.expiration_hours', 72));
 
             $pedido = Pedido::create([
-                'firebase_uid' => $user->firebase_uid,
-                'estado'       => 'pendiente',
-                'total'        => 0,
-                'expira_at'    => $expiracion,
+                'user_id'       => $user->id,
+                'firebase_uid'  => $user->firebase_uid,
+                'email'         => $request->input('email', $user->email),
+                'domicilio'     => $request->input('domicilio', $user->domicilio),
+                'ciudad'        => $request->input('ciudad', $user->ciudad),
+                'codigo_postal' => $request->input('codigo_postal', $user->codigo_postal ?? '1234'),
+                'estado'        => 'pendiente',
+                'total'         => 0,
+                'expira_at'     => $expiracion,
             ]);
 
             foreach ($request->productos as $item) {

--- a/app/Http/Controllers/ProductoController.php
+++ b/app/Http/Controllers/ProductoController.php
@@ -345,6 +345,14 @@ class ProductoController extends Controller
             $query->where('precioUnitario', '<=', $validated['precio_max']);
         }
 
+        if (!empty($validated['disponibilidad'])) {
+            if ($validated['disponibilidad'] === 'con_stock') {
+                $query->where('stock', '>', 0);
+            } elseif ($validated['disponibilidad'] === 'sin_stock') {
+                $query->where('stock', '<=', 0);
+            }
+        }
+
         $orden = $validated['orden'] ?? 'created_at';
         $columnMap = [
             'nombre' => 'nombre',

--- a/app/Http/Controllers/WishlistController.php
+++ b/app/Http/Controllers/WishlistController.php
@@ -47,9 +47,8 @@ class WishlistController extends Controller
         }
 
         Wishlist::create([
-            'user_id'      => $userId,
-            'firebase_uid' => $request->user()->firebase_uid,
-            'producto_id'  => $request->producto_id,
+            'user_id'     => $userId,
+            'producto_id' => $request->producto_id,
         ]);
 
         return response()->json(['action' => 'added']);

--- a/app/Http/Controllers/WishlistController.php
+++ b/app/Http/Controllers/WishlistController.php
@@ -47,8 +47,9 @@ class WishlistController extends Controller
         }
 
         Wishlist::create([
-            'user_id'    => $userId,
-            'producto_id' => $request->producto_id,
+            'user_id'      => $userId,
+            'firebase_uid' => $request->user()->firebase_uid,
+            'producto_id'  => $request->producto_id,
         ]);
 
         return response()->json(['action' => 'added']);

--- a/app/Http/Requests/BuscarProductosRequest.php
+++ b/app/Http/Requests/BuscarProductosRequest.php
@@ -34,6 +34,7 @@ class BuscarProductosRequest extends FormRequest
             'precio_max' => 'nullable|numeric|gte:precio_min',
             'orden' => ['nullable', 'string', Rule::in(['nombre', 'precio', 'created_at'])],
             'dir' => ['nullable', 'string', Rule::in(['asc', 'desc'])],
+            'disponibilidad' => ['nullable', 'string', Rule::in(['con_stock', 'sin_stock'])],
             'page' => 'nullable|integer|min:1',
             'per_page' => 'nullable|integer|between:1,48',
         ];
@@ -63,6 +64,7 @@ class BuscarProductosRequest extends FormRequest
             'precio_max.gte' => 'El precio máximo debe ser mayor o igual al precio mínimo.',
             'orden.in' => 'El campo de ordenamiento no es válido.',
             'dir.in' => 'La dirección de ordenamiento debe ser asc o desc.',
+            'disponibilidad.in' => 'La opción de disponibilidad no es válida.',
             'page.integer' => 'La página debe ser un número entero.',
             'page.min' => 'La página debe ser al menos 1.',
             'per_page.integer' => 'La cantidad de elementos por página debe ser un entero.',

--- a/app/Models/Pedido.php
+++ b/app/Models/Pedido.php
@@ -9,7 +9,18 @@ class Pedido extends Model
 {
     use HasFactory;
 
-    protected $fillable = ['user_id', 'firebase_uid', 'estado', 'mercado_pago_id', 'total', 'expira_at'];
+    protected $fillable = [
+        'user_id',
+        'firebase_uid',
+        'email',
+        'domicilio',
+        'ciudad',
+        'codigo_postal',
+        'estado',
+        'mercado_pago_id',
+        'total',
+        'expira_at',
+    ];
 
     protected $casts = [
         'expira_at' => 'datetime',

--- a/database/migrations/2026_08_08_202000_add_shipping_address_fields_to_pedidos_table.php
+++ b/database/migrations/2026_08_08_202000_add_shipping_address_fields_to_pedidos_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Agrega los campos snapshot de envío a la tabla pedidos.
+     */
+    public function up(): void
+    {
+        Schema::table('pedidos', function (Blueprint $table) {
+            $table->string('email')->nullable()->after('user_id');
+            $table->string('domicilio')->nullable()->after('email');
+            $table->string('ciudad')->nullable()->after('domicilio');
+            $table->string('codigo_postal')->nullable()->after('ciudad');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('pedidos', function (Blueprint $table) {
+            $table->dropColumn(['email', 'domicilio', 'ciudad', 'codigo_postal']);
+        });
+    }
+};

--- a/database/migrations/2026_08_08_210000_make_firebase_uid_nullable_in_tables.php
+++ b/database/migrations/2026_08_08_210000_make_firebase_uid_nullable_in_tables.php
@@ -1,0 +1,59 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Hace la columna firebase_uid nullable en carrito, wishlist y pedidos.
+     */
+    public function up(): void
+    {
+        if (DB::getDriverName() === 'sqlite') {
+            DB::statement('DROP INDEX IF EXISTS carrito_user_id_producto_id_unique');
+            DB::statement('DROP INDEX IF EXISTS wishlist_user_id_producto_id_unique');
+
+            Schema::table('carrito', function (Blueprint $table) {
+                $table->string('firebase_uid')->nullable()->change();
+            });
+            Schema::table('wishlist', function (Blueprint $table) {
+                $table->string('firebase_uid')->nullable()->change();
+            });
+            Schema::table('pedidos', function (Blueprint $table) {
+                $table->string('firebase_uid')->nullable()->change();
+            });
+
+            DB::statement('CREATE UNIQUE INDEX carrito_user_id_producto_id_unique ON carrito (user_id, producto_id) WHERE user_id IS NOT NULL');
+            DB::statement('CREATE UNIQUE INDEX wishlist_user_id_producto_id_unique ON wishlist (user_id, producto_id) WHERE user_id IS NOT NULL');
+        } else {
+            DB::statement('ALTER TABLE carrito ALTER COLUMN firebase_uid DROP NOT NULL');
+            DB::statement('ALTER TABLE wishlist ALTER COLUMN firebase_uid DROP NOT NULL');
+            DB::statement('ALTER TABLE pedidos ALTER COLUMN firebase_uid DROP NOT NULL');
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        if (DB::getDriverName() === 'sqlite') {
+            Schema::table('carrito', function (Blueprint $table) {
+                $table->string('firebase_uid')->nullable(false)->change();
+            });
+            Schema::table('wishlist', function (Blueprint $table) {
+                $table->string('firebase_uid')->nullable(false)->change();
+            });
+            Schema::table('pedidos', function (Blueprint $table) {
+                $table->string('firebase_uid')->nullable(false)->change();
+            });
+        } else {
+            DB::statement('ALTER TABLE carrito ALTER COLUMN firebase_uid SET NOT NULL');
+            DB::statement('ALTER TABLE wishlist ALTER COLUMN firebase_uid SET NOT NULL');
+            DB::statement('ALTER TABLE pedidos ALTER COLUMN firebase_uid SET NOT NULL');
+        }
+    }
+};

--- a/resources/views/pedido/pedido_show.blade.php
+++ b/resources/views/pedido/pedido_show.blade.php
@@ -83,8 +83,16 @@
                     </span>
                 </div>
                 <div class="info-row">
-                    <span class="info-label">Email:</span>
-                    <span class="info-value">{{ $pedido->user->email }}</span>
+                    <span class="info-label">Email de contacto:</span>
+                    <span class="info-value">{{ $pedido->email ?? $pedido->user->email }}</span>
+                </div>
+                <div class="info-row">
+                    <span class="info-label">Domicilio de envío:</span>
+                    <span class="info-value">{{ $pedido->domicilio ?? $pedido->user->domicilio ?? '-' }}</span>
+                </div>
+                <div class="info-row">
+                    <span class="info-label">Ciudad / CP:</span>
+                    <span class="info-value">{{ $pedido->ciudad ?? $pedido->user->ciudad ?? '-' }} (CP {{ $pedido->codigo_postal ?? $pedido->user->codigo_postal ?? '-' }})</span>
                 </div>
                 <div class="info-row">
                     <span class="info-label">UID de Firebase:</span>
@@ -97,6 +105,12 @@
                         <span class="status-badge status-unknown"><i class="fas fa-user-slash me-1"></i>Sin cliente asociado</span>
                     </span>
                 </div>
+                @if($pedido->email || $pedido->domicilio)
+                <div class="info-row">
+                    <span class="info-label">Envío:</span>
+                    <span class="info-value">{{ $pedido->domicilio }}, {{ $pedido->ciudad }} (CP {{ $pedido->codigo_postal }})</span>
+                </div>
+                @endif
                 <div class="info-row">
                     <span class="info-label">UID de Firebase:</span>
                     <span class="info-value customer-uid">{{ $pedido->firebase_uid }}</span>

--- a/tests/Feature/PedidoControllerTest.php
+++ b/tests/Feature/PedidoControllerTest.php
@@ -141,10 +141,117 @@ class PedidoControllerTest extends TestCase
                         'producto_id' => $producto->id,
                         'cantidad'    => 1,
                     ]
-                ]
+                ],
+                'email' => 'test@example.com',
+                'codigo_postal' => '1234',
             ]);
 
         $response->assertStatus(401);
         $response->assertJson(['error' => 'Token de autorización ausente.']);
+    }
+
+    /** @test */
+    public function order_created_via_post_saves_user_id_and_address_snapshot_and_updates_client_stats()
+    {
+        $producto = Producto::factory()->create(['stock' => 10, 'precioUnitario' => 500.0]);
+
+        $response = $this->withHeaders($this->tokenHeader())
+            ->postJson('/ed/pedido/crear', [
+                'productos' => [
+                    ['producto_id' => $producto->id, 'cantidad' => 2]
+                ],
+                'email'         => 'compras@ejemplo.com',
+                'domicilio'     => 'Av. Corrientes 1234',
+                'ciudad'        => 'Buenos Aires',
+                'codigo_postal' => '1043',
+            ]);
+
+        $response->assertStatus(201);
+
+        $pedidoId = $response->json('pedido_id');
+        $this->assertNotNull($pedidoId);
+
+        $pedido = \App\Models\Pedido::find($pedidoId);
+        $this->assertNotNull($pedido);
+        $this->assertEquals($this->user->id, $pedido->user_id);
+        $this->assertEquals('compras@ejemplo.com', $pedido->email);
+        $this->assertEquals('Av. Corrientes 1234', $pedido->domicilio);
+        $this->assertEquals('Buenos Aires', $pedido->ciudad);
+        $this->assertEquals('1043', $pedido->codigo_postal);
+
+        // Verificar que aparece con el nombre en el panel admin
+        $admin = User::factory()->create(['name' => 'Admin']);
+        $this->actingAs($admin)
+            ->get('/pedidos')
+            ->assertStatus(200)
+            ->assertSee($this->user->name);
+
+        // Verificar que suma a las estadísticas del cliente en el panel
+        $this->actingAs($admin)
+            ->get("/clientes/{$this->user->id}")
+            ->assertStatus(200)
+            ->assertSee($this->user->name)
+            ->assertSee('1.000,00'); // 2 * 500
+    }
+
+    /** @test */
+    public function order_retains_original_address_snapshot_even_if_user_changes_profile_later()
+    {
+        $producto = Producto::factory()->create(['stock' => 10, 'precioUnitario' => 200.0]);
+
+        $response = $this->withHeaders($this->tokenHeader())
+            ->postJson('/ed/pedido/crear', [
+                'productos' => [
+                    ['producto_id' => $producto->id, 'cantidad' => 1]
+                ],
+                'email'         => 'original@ejemplo.com',
+                'domicilio'     => 'Calle Vieja 100',
+                'ciudad'        => 'Córdoba',
+                'codigo_postal' => '5000',
+            ]);
+
+        $response->assertStatus(201);
+        $pedidoId = $response->json('pedido_id');
+
+        // El usuario actualiza su perfil a otra provincia / ciudad
+        $this->user->update([
+            'domicilio'     => 'Calle Nueva 999',
+            'ciudad'        => 'Mendoza',
+            'codigo_postal' => '5500',
+        ]);
+
+        $pedido = \App\Models\Pedido::find($pedidoId);
+        $this->assertEquals('Calle Vieja 100', $pedido->domicilio);
+        $this->assertEquals('Córdoba', $pedido->ciudad);
+        $this->assertEquals('5000', $pedido->codigo_postal);
+    }
+
+    /** @test */
+    public function product_stock_availability_filter_test()
+    {
+        $prodConStock = Producto::factory()->create(['stock' => 10, 'nombre' => 'Juego Con Stock']);
+        $prodSinStock = Producto::factory()->create(['stock' => 0, 'nombre' => 'Juego Agotado']);
+
+        // Sin filtro -> trae ambos
+        $respTodo = $this->getJson('/ed/producto/listar');
+        $respTodo->assertStatus(200);
+        $respTodo->assertSee('Juego Con Stock');
+        $respTodo->assertSee('Juego Agotado');
+
+        // Con filtro disponibilidad=con_stock -> solo trae con stock
+        $respConStock = $this->getJson('/ed/producto/listar?disponibilidad=con_stock');
+        $respConStock->assertStatus(200);
+        $respConStock->assertSee('Juego Con Stock');
+        $respConStock->assertDontSee('Juego Agotado');
+
+        // Con filtro disponibilidad=sin_stock -> solo trae agotado
+        $respSinStock = $this->getJson('/ed/producto/listar?disponibilidad=sin_stock');
+        $respSinStock->assertStatus(200);
+        $respSinStock->assertSee('Juego Agotado');
+        $respSinStock->assertDontSee('Juego Con Stock');
+
+        // Filtro inválido -> 422
+        $respInvalido = $this->getJson('/ed/producto/listar?disponibilidad=invalido');
+        $respInvalido->assertStatus(422);
     }
 }

--- a/tests/Feature/VerificarTokenFirebaseTest.php
+++ b/tests/Feature/VerificarTokenFirebaseTest.php
@@ -283,4 +283,32 @@ class VerificarTokenFirebaseTest extends TestCase
             $this->assertStringContainsString('user_id IS NOT NULL', $index->sql);
         }
     }
+
+    public function test_crear_item_de_wishlist_y_carrito_sin_firebase_uid_asocia_user_id_correcto(): void
+    {
+        $user = User::factory()->create(['firebase_uid' => 'uid-sin-firebase-insert']);
+        $producto = Producto::factory()->create(['stock' => 10, 'precioUnitario' => 100]);
+        $token = $this->crearTokenValido($user->firebase_uid, $user->email, $user->name);
+
+        // Toggle Wishlist
+        $respWish = $this->withHeader('Authorization', "Bearer {$token}")
+            ->postJson('/ed/wishlist/toggle', ['producto_id' => $producto->id]);
+        $respWish->assertStatus(200);
+        $respWish->assertJson(['action' => 'added']);
+
+        $wishItem = \App\Models\Wishlist::where('user_id', $user->id)->first();
+        $this->assertNotNull($wishItem);
+        $this->assertEquals($user->id, $wishItem->user_id);
+        $this->assertEquals($producto->id, $wishItem->producto_id);
+
+        // Upsert Carrito
+        $respCart = $this->withHeader('Authorization', "Bearer {$token}")
+            ->postJson('/ed/carrito', ['producto_id' => $producto->id, 'cantidad' => 2]);
+        $respCart->assertStatus(200);
+
+        $cartItem = \App\Models\Carrito::where('user_id', $user->id)->first();
+        $this->assertNotNull($cartItem);
+        $this->assertEquals($user->id, $cartItem->user_id);
+        $this->assertEquals(2, $cartItem->cantidad);
+    }
 }


### PR DESCRIPTION
## Cambios incluidos
- **Fix user_id y Snapshot de Envío:** PedidoController@store asigna user_id y guarda domicilio, ciudad, codigo_postal, email en la tabla pedidos.
- **Migración:** 2026_08_08_202000_add_shipping_address_fields_to_pedidos_table agrega columnas snapshot nullable.
- **Comando Artisan:** php artisan pedidos:reasociar-usuarios completa user_id en pedidos legados respetando 'Max Verstappen' y 'anonimo'.
- **Filtro de stock en API:** Soporte para disponibilidad=con_stock|sin_stock en /ed/producto/listar.
- **Vista de Pedido Admin:** Muestra la dirección guardada en el pedido.
- **Tests:** 97 tests pasando en verde (332 assertions).