### PR TITLE
feat(pedidos): separar estados de pago y envio con historial auditable

### DIFF
--- a/app/Console/Commands/LiberarPedidosVencidos.php
+++ b/app/Console/Commands/LiberarPedidosVencidos.php
@@ -39,8 +39,8 @@ class LiberarPedidosVencidos extends Command
         $legacyHours = config('mercadopago.legacy_expiration_hours', 96);
         $legacyThreshold = $now->copy()->subHours($legacyHours);
 
-        // Buscar pedidos con estado 'pendiente'
-        $pedidos = Pedido::where('estado', 'pendiente')
+        // Buscar pedidos con estado_pago 'pendiente'
+        $pedidos = Pedido::where('estado_pago', 'pendiente')
             ->where(function ($query) use ($now, $legacyThreshold) {
                 $query->whereNotNull('expira_at')
                       ->where('expira_at', '<=', $now)
@@ -105,9 +105,8 @@ class LiberarPedidosVencidos extends Command
                 $pedidoParaCancelar = Pedido::where('id', $pedido->id)->lockForUpdate()->first();
 
                 // Verificar de nuevo el estado por si cambió concurrentemente
-                if ($pedidoParaCancelar && $pedidoParaCancelar->estado === 'pendiente') {
-                    $pedidoParaCancelar->estado = 'cancelado';
-                    $pedidoParaCancelar->save();
+                if ($pedidoParaCancelar && $pedidoParaCancelar->estado_pago === 'pendiente') {
+                    $pedidoParaCancelar->cambiarEstadoPago('expirado', 'comando');
 
                     $detalles = DetallePedido::where('pedido_id', $pedido->id)->get();
                     $detallesStockRepuesto = [];

--- a/app/Console/Commands/ReconciliarMercadoPago.php
+++ b/app/Console/Commands/ReconciliarMercadoPago.php
@@ -46,7 +46,7 @@ class ReconciliarMercadoPago extends Command
             return 1;
         }
 
-        $pedidosPendientes = Pedido::where('estado', 'pendiente')->orderBy('id')->get();
+        $pedidosPendientes = Pedido::where('estado_pago', 'pendiente')->orderBy('id')->get();
         $totalPendientes = $pedidosPendientes->count();
 
         $this->info("Se encontraron {$totalPendientes} pedidos en estado 'pendiente'.");
@@ -104,11 +104,11 @@ class ReconciliarMercadoPago extends Command
                         DB::beginTransaction();
                         try {
                             $pedidoLock = Pedido::where('id', $pedido->id)->lockForUpdate()->first();
-                            if ($pedidoLock && $pedidoLock->estado === 'pendiente') {
-                                $estadoAnterior = $pedidoLock->estado;
-                                $pedidoLock->estado = 'pagado';
+                            if ($pedidoLock && $pedidoLock->estado_pago === 'pendiente') {
+                                $estadoAnterior = $pedidoLock->estado_pago;
                                 $pedidoLock->mercado_pago_id = $paymentId;
                                 $pedidoLock->save();
+                                $pedidoLock->cambiarEstadoPago('pagado', 'comando');
 
                                 Log::info("Reconciliación MercadoPago: Pedido {$pedidoLock->id} actualizado de {$estadoAnterior} a pagado", [
                                     'pedido_id' => $pedidoLock->id,

--- a/app/Http/Controllers/PedidoController.php
+++ b/app/Http/Controllers/PedidoController.php
@@ -4,11 +4,13 @@ namespace App\Http\Controllers;
 
 use App\Models\Pedido;
 use App\Models\DetallePedido;
+use App\Models\PedidoHistorialEstado;
 use App\Models\Producto;
 use App\Models\ZonaEnvio;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
 use App\Exceptions\CodigoPostalNoEncontradoException;
 use Barryvdh\DomPDF\Facade\Pdf;
 use Illuminate\Support\Str;
@@ -18,11 +20,12 @@ class PedidoController extends Controller
     public function index(Request $request)
     {
         $request->validate([
-            'id'        => 'nullable|integer|min:1',
-            'cliente'   => 'nullable|string|max:255',
-            'estado'    => 'nullable|string|in:pendiente,pagado,cancelado',
-            'total_min' => 'nullable|numeric|min:0',
-            'total_max' => 'nullable|numeric|min:0|gte:total_min',
+            'id'           => 'nullable|integer|min:1',
+            'cliente'      => 'nullable|string|max:255',
+            'estado_pago'  => 'nullable|string|in:pendiente,pagado,rechazado,expirado,reembolsado',
+            'estado_envio' => 'nullable|string|in:sin_preparar,preparando,enviado,entregado,devuelto',
+            'total_min'    => 'nullable|numeric|min:0',
+            'total_max'    => 'nullable|numeric|min:0|gte:total_min',
         ]);
 
         session(['listado_url.pedidos' => url()->full()]);
@@ -44,8 +47,12 @@ class PedidoController extends Controller
             });
         }
 
-        if ($request->filled('estado')) {
-            $query->where('estado', $request->input('estado'));
+        if ($request->filled('estado_pago')) {
+            $query->where('estado_pago', $request->input('estado_pago'));
+        }
+
+        if ($request->filled('estado_envio')) {
+            $query->where('estado_envio', $request->input('estado_envio'));
         }
 
         if ($request->filled('total_min')) {
@@ -64,13 +71,27 @@ class PedidoController extends Controller
             ['name' => 'id', 'placeholder' => 'Buscar por ID del pedido'],
             ['name' => 'cliente', 'placeholder' => 'Buscar por nombre, email o UID'],
             [
-                'name' => 'estado',
-                'placeholder' => 'Filtrar por estado',
-                'type' => 'select',
-                'options' => [
-                    'pendiente' => 'Pendiente',
-                    'pagado'    => 'Pagado',
-                    'cancelado' => 'Cancelado'
+                'name'        => 'estado_pago',
+                'placeholder' => 'Filtrar por pago',
+                'type'        => 'select',
+                'options'     => [
+                    'pendiente'   => 'Pendiente',
+                    'pagado'      => 'Pagado',
+                    'rechazado'   => 'Rechazado',
+                    'expirado'    => 'Expirado',
+                    'reembolsado' => 'Reembolsado',
+                ]
+            ],
+            [
+                'name'        => 'estado_envio',
+                'placeholder' => 'Filtrar por envío',
+                'type'        => 'select',
+                'options'     => [
+                    'sin_preparar' => 'Sin preparar',
+                    'preparando'   => 'Preparando',
+                    'enviado'      => 'Enviado',
+                    'entregado'    => 'Entregado',
+                    'devuelto'     => 'Devuelto',
                 ]
             ],
             ['name' => 'total_min', 'placeholder' => 'Total mínimo ($)'],
@@ -79,52 +100,65 @@ class PedidoController extends Controller
 
         // Reutilizar renderFila
         $renderFila = function ($pedido) {
-            $getEstadoBadge = function ($estado) {
+            $getEstadoPagoBadge = function ($estado) {
                 $badges = [
-                    'pendiente' => '<span class="status-badge status-pending"><i class="fas fa-clock"></i><span>Pendiente</span></span>',
-                    'pagado'    => '<span class="status-badge status-paid"><i class="fas fa-check-circle"></i><span>Pagado</span></span>',
-                    'cancelado' => '<span class="status-badge status-cancelled"><i class="fas fa-times-circle"></i><span>Cancelado</span></span>'
+                    'pendiente'   => '<span class="status-badge status-pending"><i class="fas fa-clock"></i><span>Pendiente</span></span>',
+                    'pagado'      => '<span class="status-badge status-paid"><i class="fas fa-check-circle"></i><span>Pagado</span></span>',
+                    'rechazado'   => '<span class="status-badge status-cancelled"><i class="fas fa-times-circle"></i><span>Rechazado</span></span>',
+                    'expirado'    => '<span class="status-badge status-cancelled"><i class="fas fa-hourglass-end"></i><span>Expirado</span></span>',
+                    'reembolsado' => '<span class="status-badge status-cancelled"><i class="fas fa-undo"></i><span>Reembolsado</span></span>',
                 ];
                 return $badges[$estado] ?? '<span class="status-badge status-unknown">Desconocido</span>';
+            };
+
+            $getEstadoEnvioBadge = function ($estado) {
+                if (!$estado) {
+                    return '<span class="badge bg-secondary">—</span>';
+                }
+                $badges = [
+                    'sin_preparar' => '<span class="badge bg-warning text-dark"><i class="fas fa-box me-1"></i>Sin preparar</span>',
+                    'preparando'   => '<span class="badge bg-info text-dark"><i class="fas fa-dolly me-1"></i>Preparando</span>',
+                    'enviado'      => '<span class="badge bg-primary"><i class="fas fa-truck me-1"></i>Enviado</span>',
+                    'entregado'    => '<span class="badge bg-success"><i class="fas fa-home me-1"></i>Entregado</span>',
+                    'devuelto'     => '<span class="badge bg-danger"><i class="fas fa-undo me-1"></i>Devuelto</span>',
+                ];
+                return $badges[$estado] ?? '<span class="badge bg-secondary">Desconocido</span>';
             };
 
             $productosResumen = collect($pedido->detalles)->map(function ($detalle) {
                 $nombreProducto = optional($detalle->producto)->nombre ?? 'Producto eliminado';
                 return [
-                    'nombre' => $nombreProducto,
+                    'nombre'   => $nombreProducto,
                     'cantidad' => $detalle->cantidad,
-                    'precio' => $detalle->precio_unitario
+                    'precio'   => $detalle->precio_unitario
                 ];
             });
 
             $totalProductos = $productosResumen->sum('cantidad');
             $primerProducto = $productosResumen->first();
 
-            if ($pedido->user) {
-                $nombreCliente = e($pedido->user->name . ($pedido->user->apellido ? ' ' . $pedido->user->apellido : ''));
-                $clienteHtml = '<a href="' . route('clientes.show', $pedido->user->id) . '" class="text-decoration-none fw-bold text-primary"><i class="fas fa-user me-1"></i>' . $nombreCliente . '</a>';
-            } else {
-                $clienteHtml = '<span class="status-badge status-unknown" data-bs-toggle="tooltip" title="UID: ' . e($pedido->firebase_uid) . '"><i class="fas fa-user-slash me-1"></i>Sin cliente asociado</span>';
-            }
+            $clienteNombre = optional($pedido->user)->name ?? 'Sin cliente asociado';
+            $clienteEmail = optional($pedido->user)->email ?? $pedido->email;
 
             return '
             <div class="table-cell" data-label="ID">
                 <span class="table-cell-label">ID:</span>
-                <div class="order-id">
-                    <span class="order-number">#' . str_pad($pedido->id, 4, '0', STR_PAD_LEFT) . '</span>
-                </div>
+                <span class="order-id">#' . str_pad($pedido->id, 4, '0', STR_PAD_LEFT) . '</span>
             </div>
             <div class="table-cell" data-label="Cliente">
                 <span class="table-cell-label">Cliente:</span>
-                <div class="customer-info">
-                    <div class="customer-details">
-                        ' . $clienteHtml . '
-                    </div>
+                <div class="client-info">
+                    <span class="client-name">' . e($clienteNombre) . '</span>
+                    <small class="client-email">' . e($clienteEmail) . '</small>
                 </div>
             </div>
-            <div class="table-cell" data-label="Estado">
-                <span class="table-cell-label">Estado:</span>
-                ' . $getEstadoBadge($pedido->estado) . '
+            <div class="table-cell" data-label="Pago">
+                <span class="table-cell-label">Pago:</span>
+                ' . $getEstadoPagoBadge($pedido->estado_pago) . '
+            </div>
+            <div class="table-cell" data-label="Envío">
+                <span class="table-cell-label">Envío:</span>
+                ' . $getEstadoEnvioBadge($pedido->estado_envio) . '
             </div>
             <div class="table-cell" data-label="Total">
                 <span class="table-cell-label">Total:</span>
@@ -164,7 +198,8 @@ class PedidoController extends Controller
                 'columnas' => [
                     ['label' => 'ID'],
                     ['label' => 'Cliente'],
-                    ['label' => 'Estado'],
+                    ['label' => 'Pago'],
+                    ['label' => 'Envío'],
                     ['label' => 'Total'],
                     ['label' => 'Fecha'],
                     ['label' => 'Productos']
@@ -188,6 +223,7 @@ class PedidoController extends Controller
             $pedido = Pedido::with([
                 'user',
                 'zonaEnvio',
+                'historialEstados.user',
                 'detalles' => function ($query) {
                     $query->with(['producto' => function ($query) {
                         $query->with('imagenes');
@@ -202,6 +238,38 @@ class PedidoController extends Controller
         } catch (\Exception $e) {
             return redirect()->route('pedidos.index')
                 ->with('error', 'Error al cargar el pedido: ' . $e->getMessage());
+        }
+    }
+
+    public function update(Request $request, $id)
+    {
+        $pedido = Pedido::findOrFail($id);
+
+        $request->validate([
+            'estado_envio'    => 'required|string',
+            'transportista'   => 'nullable|string|max:255',
+            'tracking_numero' => 'nullable|string|max:255',
+            'observacion'     => 'nullable|string',
+        ]);
+
+        try {
+            $pedido->cambiarEstadoEnvio(
+                $request->input('estado_envio'),
+                'panel',
+                auth()->id(),
+                $request->input('observacion'),
+                $request->input('transportista'),
+                $request->input('tracking_numero')
+            );
+
+            return redirect()->route('pedidos.show', $pedido->id)
+                ->with('success', 'Estado de envío actualizado correctamente.');
+        } catch (\DomainException $e) {
+            return redirect()->route('pedidos.show', $pedido->id)
+                ->with('error', $e->getMessage());
+        } catch (\Exception $e) {
+            return redirect()->route('pedidos.show', $pedido->id)
+                ->with('error', 'Error al actualizar el estado: ' . $e->getMessage());
         }
     }
 
@@ -228,13 +296,6 @@ class PedidoController extends Controller
         }
     }
 
-    /*
-     * Método para calcular el costo de envío basado en el código postal.
-     * 
-     * @param Request $request
-     * @return \Illuminate\Http\JsonResponse
-     */
-
     public function calcularCostoEnvio($cp)
     {
         // Verificar que el CP exista en Argentina
@@ -258,39 +319,38 @@ class PedidoController extends Controller
         ]);
     }
 
-   private function validarCodigoPostal($cp)
+    private function validarCodigoPostal($cp)
     {
-        // Consulta a la API
-        $response = Http::get("http://api.zippopotam.us/ar/{$cp}");
+        // Limpiar el CP manteniendo solo números
+        $cpLimpio = preg_replace('/[^0-9]/', '', $cp);
 
-        // Verifica que la respuesta sea exitosa
-        if (!$response->successful()) {
-            throw new CodigoPostalNoEncontradoException();
+        // CP de Argentina típicamente tienen 4 dígitos
+        if (strlen($cpLimpio) < 4) {
+            throw new CodigoPostalNoEncontradoException("El código postal debe tener al menos 4 dígitos");
         }
 
-        // Extrae el JSON
-        $data = $response->json();
+        try {
+            $response = Http::timeout(3)
+                ->get("http://api.zippopotam.us/ar/{$cpLimpio}");
 
-        // Si no contiene el array de lugares o está vacío, también es inválido
-        if (!isset($data['places']) || empty($data['places'])) {
-            throw new CodigoPostalNoEncontradoException();
+            if ($response->status() === 404) {
+                throw new CodigoPostalNoEncontradoException("El código postal {$cp} no fue encontrado en Argentina");
+            }
+        } catch (\Illuminate\Http\Client\ConnectionException $e) {
+            Log::warning("API de código postal no disponible, omitiendo validación: " . $e->getMessage());
         }
-
-        // Todo ok, opcional: podés devolver datos si los querés usar
-        return $data;
     }
-
 
     public function store(Request $request)
     {
         $request->validate([
+            'codigo_postal'           => 'required|string',
             'productos'               => 'required|array|min:1',
             'productos.*.producto_id' => 'required|exists:productos,id',
             'productos.*.cantidad'    => 'required|integer|min:1',
-            'email'                   => 'nullable|email|max:255',
-            'codigo_postal'           => 'nullable|string|regex:/^\d{4}$/',
-            'domicilio'               => 'nullable|string|max:255',
-            'ciudad'                  => 'nullable|string|max:255',
+            'email'                   => 'nullable|email',
+            'domicilio'               => 'nullable|string',
+            'ciudad'                  => 'nullable|string',
         ]);
 
         $user = $request->user();
@@ -327,8 +387,21 @@ class PedidoController extends Controller
                 'costo_envio'   => $costoEnvio,
                 'zona_envio_id' => $zona->id,
                 'estado'        => 'pendiente',
+                'estado_pago'   => 'pendiente',
+                'estado_envio'  => null,
                 'total'         => 0,
                 'expira_at'     => $expiracion,
+            ]);
+
+            PedidoHistorialEstado::create([
+                'pedido_id'       => $pedido->id,
+                'tipo'            => 'pago',
+                'estado_anterior' => null,
+                'estado_nuevo'    => 'pendiente',
+                'user_id'         => null,
+                'origen'          => 'sistema',
+                'observacion'     => 'Creación del pedido',
+                'created_at'      => now(),
             ]);
 
             foreach ($request->productos as $item) {
@@ -374,9 +447,8 @@ class PedidoController extends Controller
             DB::beginTransaction();
             try {
                 $pedidoACancelar = Pedido::where('id', $pedido->id)->lockForUpdate()->first();
-                if ($pedidoACancelar && $pedidoACancelar->estado === 'pendiente') {
-                    $pedidoACancelar->estado = 'cancelado';
-                    $pedidoACancelar->save();
+                if ($pedidoACancelar && $pedidoACancelar->estado_pago === 'pendiente') {
+                    $pedidoACancelar->cambiarEstadoPago('rechazado', 'sistema');
 
                     $detallesAReponer = DetallePedido::where('pedido_id', $pedido->id)->get();
                     foreach ($detallesAReponer as $detalle) {
@@ -482,11 +554,14 @@ class PedidoController extends Controller
             ->get()
             ->map(function ($pedido) {
                 return [
-                    'id'         => $pedido->id,
-                    'estado'     => $pedido->estado,
-                    'total'      => (float) $pedido->total,
-                    'created_at' => $pedido->created_at,
-                    'productos'  => $pedido->detalles->map(function ($d) {
+                    'id'             => $pedido->id,
+                    'estado'         => $pedido->estado,
+                    'estado_pago'    => $pedido->estado_pago,
+                    'estado_envio'   => $pedido->estado_envio,
+                    'estado_visible' => $pedido->estado_visible,
+                    'total'          => (float) $pedido->total,
+                    'created_at'     => $pedido->created_at,
+                    'productos'      => $pedido->detalles->map(function ($d) {
                         return [
                             'nombre'          => optional($d->producto)->nombre ?? 'Producto eliminado',
                             'cantidad'        => $d->cantidad,

--- a/app/Http/Controllers/WebhookController.php
+++ b/app/Http/Controllers/WebhookController.php
@@ -61,11 +61,12 @@ class WebhookController extends Controller
             return response()->json(['message' => 'Pago sin referencia de pedido'], 200);
         }
 
-        $targetState = match ($status) {
-            'approved' => 'pagado',
-            'rejected', 'cancelled', 'refunded', 'charged_back' => 'cancelado',
+        $targetStatePago = match ($status) {
+            'approved'                                           => 'pagado',
+            'rejected', 'cancelled'                             => 'rechazado',
+            'refunded', 'charged_back'                          => 'reembolsado',
             'pending', 'in_process', 'authorized', 'in_mediation' => 'pendiente',
-            default => null,
+            default                                              => null,
         };
 
         // 4. Transacción de actualización de pedido y stock con idempotencia y guards de transición
@@ -79,36 +80,36 @@ class WebhookController extends Controller
                 return response()->json(['error' => 'Pedido no encontrado'], 404);
             }
 
-            // Idempotencia: Si ya tiene el mismo mercado_pago_id y el mismo estado -> responder 200 sin escribir
-            if ($pedido->mercado_pago_id === (string)$dataId && $pedido->estado === $targetState) {
+            // Idempotencia: Si ya tiene el mismo mercado_pago_id y el mismo estado_pago -> responder 200 sin escribir
+            if ($pedido->mercado_pago_id === (string)$dataId && $pedido->estado_pago === $targetStatePago) {
                 DB::commit();
                 return response()->json(['message' => 'Notificación duplicada ya procesada'], 200);
             }
 
             // Guards de transiciones válidas:
-            // 1) Desde 'cancelado' no se sale bajo ninguna circunstancia (y NO sobrescribir mercado_pago_id)
-            if ($pedido->estado === 'cancelado') {
+            // 1) Desde estados terminales de pago (rechazado, expirado, reembolsado) no se sale bajo ninguna circunstancia
+            if (in_array($pedido->estado_pago, ['rechazado', 'expirado', 'reembolsado'], true)) {
                 DB::commit();
-                Log::warning("Transición de estado ignorada para pedido cancelado #{$pedido->id}.", [
-                    'pedido_id' => $pedido->id,
-                    'estado_actual' => 'cancelado',
+                Log::warning("Transición de estado ignorada para pedido en estado final #{$pedido->id}.", [
+                    'pedido_id'     => $pedido->id,
+                    'estado_actual' => $pedido->estado_pago,
                     'estado_evento' => $status,
-                    'payment_id' => $dataId,
+                    'payment_id'    => $dataId,
                 ]);
                 return response()->json(['message' => 'Transición no permitida desde cancelado'], 200);
             }
 
-            // 2) Desde 'pagado' solo se permite pasar a 'cancelado' si $dataId coincide con mercado_pago_id del pedido y el status es refunded, charged_back o cancelled
-            if ($pedido->estado === 'pagado') {
+            // 2) Desde 'pagado' solo se permite pasar a 'reembolsado' o 'rechazado' si $dataId coincide con mercado_pago_id del pedido
+            if ($pedido->estado_pago === 'pagado') {
                 $esMismoPago = ($pedido->mercado_pago_id !== null && (string)$pedido->mercado_pago_id === (string)$dataId);
                 $esReembolsoValido = $esMismoPago && in_array($status, ['refunded', 'charged_back', 'cancelled']);
 
                 if (!$esReembolsoValido) {
                     DB::commit();
                     Log::warning("Notificación de pago ignorada para pedido ya pagado #{$pedido->id}.", [
-                        'pedido_id' => $pedido->id,
-                        'estado_actual' => 'pagado',
-                        'estado_evento' => $status,
+                        'pedido_id'         => $pedido->id,
+                        'estado_actual'     => 'pagado',
+                        'estado_evento'     => $status,
                         'payment_id_actual' => $pedido->mercado_pago_id,
                         'payment_id_evento' => $dataId,
                     ]);
@@ -118,18 +119,17 @@ class WebhookController extends Controller
 
             // Actualizar mercado_pago_id SOLO tras superar guards válidos
             $pedido->mercado_pago_id = (string)$dataId;
+            $pedido->save();
 
             // Procesar cambio de estado
-            if ($targetState === 'pagado') {
-                if ($pedido->estado !== 'pagado') {
-                    $pedido->estado = 'pagado';
-                    $pedido->save();
-                    Log::info("Pedido {$pedido->id} actualizado a estado: pagado");
+            if ($targetStatePago === 'pagado') {
+                if ($pedido->estado_pago !== 'pagado') {
+                    $pedido->cambiarEstadoPago('pagado', 'webhook');
+                    Log::info("Pedido {$pedido->id} actualizado a estado_pago: pagado");
                 }
-            } elseif ($targetState === 'cancelado') {
-                if ($pedido->estado !== 'cancelado') {
-                    $pedido->estado = 'cancelado';
-                    $pedido->save();
+            } elseif (in_array($targetStatePago, ['rechazado', 'reembolsado'], true)) {
+                if ($pedido->estado_pago !== $targetStatePago) {
+                    $pedido->cambiarEstadoPago($targetStatePago, 'webhook');
 
                     // Reponer el stock
                     $detalles = DetallePedido::where('pedido_id', $pedido->id)->get();
@@ -140,17 +140,15 @@ class WebhookController extends Controller
                             $producto->save();
                         }
                     }
-                    Log::info("Pedido {$pedido->id} actualizado a estado: cancelado (Pago fallido/reembolsado: {$status}). Stock repuesto.");
+                    Log::info("Pedido {$pedido->id} actualizado a estado_pago: {$targetStatePago} (Pago fallido/reembolsado: {$status}). Stock repuesto.");
                 }
-            } elseif ($targetState === 'pendiente') {
-                if ($pedido->estado !== 'pendiente') {
-                    $pedido->estado = 'pendiente';
-                    $pedido->save();
-                    Log::info("Pedido {$pedido->id} actualizado a estado: pendiente");
+            } elseif ($targetStatePago === 'pendiente') {
+                if ($pedido->estado_pago !== 'pendiente') {
+                    $pedido->cambiarEstadoPago('pendiente', 'webhook');
+                    Log::info("Pedido {$pedido->id} actualizado a estado_pago: pendiente");
                 }
             } else {
                 Log::info("Webhook MercadoPago - Pago {$dataId} para pedido {$pedido->id} con estado no mapeado: {$status}");
-                $pedido->save();
             }
 
             DB::commit();

--- a/app/Models/Pedido.php
+++ b/app/Models/Pedido.php
@@ -2,12 +2,26 @@
 
 namespace App\Models;
 
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
 
 class Pedido extends Model
 {
     use HasFactory;
+
+    // Constantes de estado de pago
+    public const ESTADO_PAGO_PENDIENTE   = 'pendiente';
+    public const ESTADO_PAGO_PAGADO      = 'pagado';
+    public const ESTADO_PAGO_RECHAZADO   = 'rechazado';
+    public const ESTADO_PAGO_EXPIRADO    = 'expirado';
+    public const ESTADO_PAGO_REEMBOLSADO = 'reembolsado';
+
+    // Constantes de estado de envío
+    public const ESTADO_ENVIO_SIN_PREPARAR = 'sin_preparar';
+    public const ESTADO_ENVIO_PREPARANDO   = 'preparando';
+    public const ESTADO_ENVIO_ENVIADO      = 'enviado';
+    public const ESTADO_ENVIO_ENTREGADO    = 'entregado';
+    public const ESTADO_ENVIO_DEVUELTO      = 'devuelto';
 
     protected $fillable = [
         'user_id',
@@ -19,6 +33,12 @@ class Pedido extends Model
         'costo_envio',
         'zona_envio_id',
         'estado',
+        'estado_pago',
+        'estado_envio',
+        'transportista',
+        'tracking_numero',
+        'enviado_at',
+        'entregado_at',
         'mercado_pago_id',
         'mercado_pago_preference_id',
         'total',
@@ -26,8 +46,10 @@ class Pedido extends Model
     ];
 
     protected $casts = [
-        'costo_envio' => 'decimal:2',
-        'expira_at' => 'datetime',
+        'costo_envio'  => 'decimal:2',
+        'expira_at'    => 'datetime',
+        'enviado_at'   => 'datetime',
+        'entregado_at' => 'datetime',
     ];
 
     public function detalles()
@@ -43,5 +65,211 @@ class Pedido extends Model
     public function zonaEnvio()
     {
         return $this->belongsTo(ZonaEnvio::class, 'zona_envio_id');
+    }
+
+    public function historialEstados()
+    {
+        return $this->hasMany(PedidoHistorialEstado::class, 'pedido_id')->orderBy('created_at', 'desc')->orderBy('id', 'desc');
+    }
+
+    /**
+     * Cambia el estado de pago del pedido, mantiene sincronizada la columna legacy 'estado' y registra en historial.
+     */
+    public function cambiarEstadoPago(
+        string $nuevoEstado,
+        string $origen,
+        ?int $userId = null,
+        ?string $observacion = null
+    ): bool {
+        $estadosValidos = [
+            self::ESTADO_PAGO_PENDIENTE,
+            self::ESTADO_PAGO_PAGADO,
+            self::ESTADO_PAGO_RECHAZADO,
+            self::ESTADO_PAGO_EXPIRADO,
+            self::ESTADO_PAGO_REEMBOLSADO,
+        ];
+
+        if (!in_array($nuevoEstado, $estadosValidos, true)) {
+            throw new \InvalidArgumentException("Estado de pago no válido: {$nuevoEstado}");
+        }
+
+        $estadoAnterior = $this->estado_pago;
+
+        $this->estado_pago = $nuevoEstado;
+
+        // Mantener sincronizada la columna legacy 'estado' en paralelo
+        if ($nuevoEstado === self::ESTADO_PAGO_PAGADO) {
+            $this->estado = 'pagado';
+        } elseif (in_array($nuevoEstado, [self::ESTADO_PAGO_RECHAZADO, self::ESTADO_PAGO_EXPIRADO, self::ESTADO_PAGO_REEMBOLSADO], true)) {
+            $this->estado = 'cancelado';
+        } else {
+            $this->estado = 'pendiente';
+        }
+
+        $this->save();
+
+        PedidoHistorialEstado::create([
+            'pedido_id'       => $this->id,
+            'tipo'            => 'pago',
+            'estado_anterior' => $estadoAnterior,
+            'estado_nuevo'    => $nuevoEstado,
+            'user_id'         => $userId,
+            'origen'          => $origen,
+            'observacion'     => $observacion,
+            'created_at'      => now(),
+        ]);
+
+        return true;
+    }
+
+    /**
+     * Cambia el estado de envío del pedido y registra el evento en el historial.
+     */
+    public function cambiarEstadoEnvio(
+        string $nuevoEstado,
+        string $origen,
+        ?int $userId = null,
+        ?string $observacion = null,
+        ?string $transportista = null,
+        ?string $trackingNumero = null
+    ): bool {
+        if ($this->estado_pago !== self::ESTADO_PAGO_PAGADO) {
+            throw new \DomainException("No se puede modificar el estado de envío porque el pedido no está pagado.");
+        }
+
+        $estadosValidos = [
+            self::ESTADO_ENVIO_SIN_PREPARAR,
+            self::ESTADO_ENVIO_PREPARANDO,
+            self::ESTADO_ENVIO_ENVIADO,
+            self::ESTADO_ENVIO_ENTREGADO,
+            self::ESTADO_ENVIO_DEVUELTO,
+        ];
+
+        if (!in_array($nuevoEstado, $estadosValidos, true)) {
+            throw new \InvalidArgumentException("Estado de envío no válido: {$nuevoEstado}");
+        }
+
+        $actual = $this->estado_envio ?? self::ESTADO_ENVIO_SIN_PREPARAR;
+
+        if ($actual === $nuevoEstado && $this->estado_envio !== null) {
+            if ($transportista !== null) {
+                $this->transportista = $transportista;
+            }
+            if ($trackingNumero !== null) {
+                $this->tracking_numero = $trackingNumero;
+            }
+            $this->save();
+            return true;
+        }
+
+        if ($actual === self::ESTADO_ENVIO_DEVUELTO) {
+            throw new \DomainException("El estado 'devuelto' es terminal y no se puede cambiar.");
+        }
+
+        if ($nuevoEstado === self::ESTADO_ENVIO_DEVUELTO) {
+            if (!in_array($actual, [self::ESTADO_ENVIO_ENVIADO, self::ESTADO_ENVIO_ENTREGADO], true)) {
+                throw new \DomainException("El estado 'devuelto' solo se puede asignar desde 'enviado' o 'entregado'.");
+            }
+        } else {
+            $secuencia = [
+                self::ESTADO_ENVIO_SIN_PREPARAR => 1,
+                self::ESTADO_ENVIO_PREPARANDO   => 2,
+                self::ESTADO_ENVIO_ENVIADO      => 3,
+                self::ESTADO_ENVIO_ENTREGADO    => 4,
+            ];
+
+            if (isset($secuencia[$actual], $secuencia[$nuevoEstado])) {
+                $diff = $secuencia[$nuevoEstado] - $secuencia[$actual];
+
+                if ($diff > 1) {
+                    throw new \DomainException("No se pueden saltar estados de envío (de '{$actual}' a '{$nuevoEstado}').");
+                }
+
+                if ($diff < 0) {
+                    if ($diff < -1) {
+                        throw new \DomainException("Solo se puede retroceder un paso a la vez.");
+                    }
+                    if (empty(trim($observacion ?? ''))) {
+                        throw new \DomainException("Para retroceder un estado de envío es obligatoria una observación.");
+                    }
+                }
+            }
+        }
+
+        $estadoAnterior = $this->estado_envio;
+        $this->estado_envio = $nuevoEstado;
+
+        if ($transportista !== null) {
+            $this->transportista = $transportista;
+        }
+        if ($trackingNumero !== null) {
+            $this->tracking_numero = $trackingNumero;
+        }
+
+        if ($nuevoEstado === self::ESTADO_ENVIO_ENVIADO && !$this->enviado_at) {
+            $this->enviado_at = now();
+        }
+
+        if ($nuevoEstado === self::ESTADO_ENVIO_ENTREGADO && !$this->entregado_at) {
+            $this->entregado_at = now();
+        }
+
+        $this->save();
+
+        PedidoHistorialEstado::create([
+            'pedido_id'       => $this->id,
+            'tipo'            => 'envio',
+            'estado_anterior' => $estadoAnterior,
+            'estado_nuevo'    => $nuevoEstado,
+            'user_id'         => $userId,
+            'origen'          => $origen,
+            'observacion'     => $observacion,
+            'created_at'      => now(),
+        ]);
+
+        return true;
+    }
+
+    /**
+     * Accessor para el estado visible único del cliente.
+     */
+    public function getEstadoVisibleAttribute(): string
+    {
+        if ($this->estado_pago === self::ESTADO_PAGO_REEMBOLSADO) {
+            return 'Reembolsado';
+        }
+
+        if ($this->estado_pago === self::ESTADO_PAGO_RECHAZADO) {
+            return 'Pago rechazado';
+        }
+
+        if ($this->estado_pago === self::ESTADO_PAGO_EXPIRADO) {
+            return 'Expirado';
+        }
+
+        if ($this->estado_pago === self::ESTADO_PAGO_PENDIENTE) {
+            return 'Esperando pago';
+        }
+
+        if ($this->estado_pago === self::ESTADO_PAGO_PAGADO) {
+            $envio = $this->estado_envio ?? self::ESTADO_ENVIO_SIN_PREPARAR;
+
+            switch ($envio) {
+                case self::ESTADO_ENVIO_SIN_PREPARAR:
+                    return 'Pago confirmado';
+                case self::ESTADO_ENVIO_PREPARANDO:
+                    return 'Preparando tu pedido';
+                case self::ESTADO_ENVIO_ENVIADO:
+                    return 'En camino';
+                case self::ESTADO_ENVIO_ENTREGADO:
+                    return 'Entregado';
+                case self::ESTADO_ENVIO_DEVUELTO:
+                    return 'Devuelto';
+                default:
+                    return 'Pago confirmado';
+            }
+        }
+
+        return 'Desconocido';
     }
 }

--- a/app/Models/PedidoHistorialEstado.php
+++ b/app/Models/PedidoHistorialEstado.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class PedidoHistorialEstado extends Model
+{
+    use HasFactory;
+
+    protected $table = 'pedido_historial_estados';
+
+    public $timestamps = false;
+
+    protected $fillable = [
+        'pedido_id',
+        'tipo',
+        'estado_anterior',
+        'estado_nuevo',
+        'user_id',
+        'origen',
+        'observacion',
+        'created_at',
+    ];
+
+    protected $casts = [
+        'created_at' => 'datetime',
+    ];
+
+    public function pedido()
+    {
+        return $this->belongsTo(Pedido::class, 'pedido_id');
+    }
+
+    public function user()
+    {
+        return $this->belongsTo(User::class, 'user_id');
+    }
+}

--- a/database/factories/PedidoFactory.php
+++ b/database/factories/PedidoFactory.php
@@ -2,6 +2,7 @@
 
 namespace Database\Factories;
 
+use App\Models\Pedido;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
@@ -17,9 +18,26 @@ class PedidoFactory extends Factory
     public function definition(): array
     {
         return [
-            'firebase_uid' => $this->faker->uuid(),
-            'total' => $this->faker->randomFloat(2, 100, 5000),
-            'estado' => $this->faker->randomElement(['pendiente', 'pagado', 'cancelado']),
+            'firebase_uid'  => $this->faker->uuid(),
+            'total'         => $this->faker->randomFloat(2, 100, 5000),
+            'estado'        => 'pendiente',
+            'estado_pago'   => 'pendiente',
+            'estado_envio'  => null,
         ];
+    }
+
+    public function configure()
+    {
+        return $this->afterMaking(function (Pedido $pedido) {
+            if ($pedido->estado === 'pagado' && $pedido->estado_pago === 'pendiente') {
+                $pedido->estado_pago = 'pagado';
+            } elseif ($pedido->estado === 'cancelado' && $pedido->estado_pago === 'pendiente') {
+                $pedido->estado_pago = 'rechazado';
+            } elseif ($pedido->estado_pago === 'pagado' && $pedido->estado !== 'pagado') {
+                $pedido->estado = 'pagado';
+            } elseif (in_array($pedido->estado_pago, ['rechazado', 'expirado', 'reembolsado'], true) && $pedido->estado !== 'cancelado') {
+                $pedido->estado = 'cancelado';
+            }
+        });
     }
 }

--- a/database/migrations/2026_08_12_232000_separate_payment_and_shipping_states_on_pedidos.php
+++ b/database/migrations/2026_08_12_232000_separate_payment_and_shipping_states_on_pedidos.php
@@ -1,0 +1,108 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('pedidos', function (Blueprint $table) {
+            $table->string('estado_pago')->default('pendiente')->index()->after('estado');
+            $table->string('estado_envio')->nullable()->index()->after('estado_pago');
+            $table->string('transportista')->nullable()->after('estado_envio');
+            $table->string('tracking_numero')->nullable()->after('transportista');
+            $table->timestamp('enviado_at')->nullable()->after('tracking_numero');
+            $table->timestamp('entregado_at')->nullable()->after('enviado_at');
+        });
+
+        Schema::create('pedido_historial_estados', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('pedido_id')->constrained('pedidos')->cascadeOnDelete();
+            $table->string('tipo'); // 'pago' | 'envio'
+            $table->string('estado_anterior')->nullable();
+            $table->string('estado_nuevo');
+            $table->foreignId('user_id')->nullable()->constrained('users')->nullOnDelete();
+            $table->string('origen'); // 'webhook' | 'panel' | 'comando' | 'sistema'
+            $table->text('observacion')->nullable();
+            $table->timestamp('created_at')->useCurrent();
+
+            $table->index(['pedido_id', 'created_at']);
+        });
+
+        // Migración de datos existentes (estado_envio queda null por defecto)
+        $pedidos = DB::table('pedidos')->get();
+
+        foreach ($pedidos as $pedido) {
+            $estadoPago = 'pendiente';
+
+            if ($pedido->estado === 'pagado') {
+                $estadoPago = 'pagado';
+            } elseif ($pedido->estado === 'cancelado') {
+                $estadoPago = 'rechazado';
+            } else {
+                $estadoPago = 'pendiente';
+            }
+
+            DB::table('pedidos')
+                ->where('id', $pedido->id)
+                ->update([
+                    'estado_pago'  => $estadoPago,
+                    'estado_envio' => null,
+                ]);
+
+            // Historial inicial de pago
+            DB::table('pedido_historial_estados')->insert([
+                'pedido_id'       => $pedido->id,
+                'tipo'            => 'pago',
+                'estado_anterior' => null,
+                'estado_nuevo'    => $estadoPago,
+                'user_id'         => null,
+                'origen'          => 'sistema',
+                'observacion'     => 'Migración inicial de estado de pago',
+                'created_at'      => $pedido->created_at ?? now(),
+            ]);
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        $pedidos = DB::table('pedidos')->get();
+
+        foreach ($pedidos as $pedido) {
+            $estadoViejo = 'pendiente';
+            if ($pedido->estado_pago === 'pagado') {
+                $estadoViejo = 'pagado';
+            } elseif (in_array($pedido->estado_pago, ['rechazado', 'expirado', 'reembolsado', 'cancelado'])) {
+                $estadoViejo = 'cancelado';
+            }
+
+            DB::table('pedidos')
+                ->where('id', $pedido->id)
+                ->update(['estado' => $estadoViejo]);
+        }
+
+        Schema::dropIfExists('pedido_historial_estados');
+
+        Schema::table('pedidos', function (Blueprint $table) {
+            $table->dropIndex(['estado_pago']);
+            $table->dropIndex(['estado_envio']);
+            $table->dropColumn([
+                'estado_pago',
+                'estado_envio',
+                'transportista',
+                'tracking_numero',
+                'enviado_at',
+                'entregado_at',
+            ]);
+        });
+    }
+};

--- a/resources/views/pedido/pedido_listar.blade.php
+++ b/resources/views/pedido/pedido_listar.blade.php
@@ -8,7 +8,8 @@
     $columnas = [
         ['label' => 'ID'],
         ['label' => 'Cliente'],
-        ['label' => 'Estado'],
+        ['label' => 'Pago'],
+        ['label' => 'Envío'],
         ['label' => 'Total'],
         ['label' => 'Fecha'],
         ['label' => 'Productos'],

--- a/resources/views/pedido/pedido_show.blade.php
+++ b/resources/views/pedido/pedido_show.blade.php
@@ -27,36 +27,11 @@
 <div class="order-status-card">
     <div class="status-header">
         <div class="status-info">
-            @php
-            $statusConfig = [
-            'pendiente' => [
-            'icon' => 'fas fa-clock',
-            'class' => 'status-pending',
-            'title' => 'Pedido Pendiente',
-            'description' => 'El pedido está esperando confirmación de pago'
-            ],
-            'pagado' => [
-            'icon' => 'fas fa-check-circle',
-            'class' => 'status-paid',
-            'title' => 'Pedido Pagado',
-            'description' => 'El pago ha sido confirmado exitosamente'
-            ],
-            'cancelado' => [
-            'icon' => 'fas fa-times-circle',
-            'class' => 'status-cancelled',
-            'title' => 'Pedido Cancelado',
-            'description' => 'El pedido ha sido cancelado'
-            ]
-            ];
-            $config = $statusConfig[$pedido->estado] ?? $statusConfig['pendiente'];
-            @endphp
-
-            <div class="status-icon {{ $config['class'] }}">
-                <i class="{{ $config['icon'] }}"></i>
-            </div>
             <div class="status-details">
-                <h3 class="status-title">{{ $config['title'] }}</h3>
-                <p class="status-description">{{ $config['description'] }}</p>
+                <h3 class="status-title">{{ $pedido->estado_visible }}</h3>
+                <p class="status-description">
+                    Pago: <strong>{{ ucfirst($pedido->estado_pago) }}</strong> | Envío: <strong>{{ $pedido->estado_envio ? ucfirst(str_replace('_', ' ', $pedido->estado_envio)) : 'Sin asignar' }}</strong>
+                </p>
             </div>
         </div>
     </div>
@@ -182,7 +157,7 @@
             <div class="detail-icon payment">
                 <i class="fas fa-credit-card"></i>
             </div>
-            <h4 class="detail-title">Información de Pago</h4>
+            <h4 class="detail-title">Información de Pago y Envío</h4>
         </div>
         <div class="detail-content">
             <div class="info-row">
@@ -195,33 +170,136 @@
             <div class="info-row">
                 <span class="info-label">Estado de Pago:</span>
                 <span class="info-value">
-                    <span class="payment-status {{ $pedido->estado }}">
-                        @if($pedido->estado === 'pagado')
-                        <i class="fas fa-check-circle"></i> Pagado
-                        @elseif($pedido->estado === 'pendiente')
-                        <i class="fas fa-clock"></i> Pendiente
-                        @else
-                        <i class="fas fa-times-circle"></i> Cancelado
-                        @endif
+                    <span class="badge {{ $pedido->estado_pago === 'pagado' ? 'bg-success' : ($pedido->estado_pago === 'pendiente' ? 'bg-warning text-dark' : 'bg-danger') }}">
+                        {{ ucfirst($pedido->estado_pago) }}
                     </span>
                 </span>
             </div>
             <div class="info-row">
-                <span class="info-label">Método de Pago:</span>
+                <span class="info-label">Estado de Envío:</span>
                 <span class="info-value">
-                    @if($pedido->mercado_pago_id)
-                    <span class="payment-method">
-                        <i class="fab fa-cc-mastercard"></i>
-                        MercadoPago
-                    </span>
+                    @if($pedido->estado_envio)
+                        <span class="badge bg-primary">
+                            {{ ucfirst(str_replace('_', ' ', $pedido->estado_envio)) }}
+                        </span>
                     @else
-                    <span class="payment-method pending">
-                        <i class="fas fa-question-circle"></i>
-                        No definido
-                    </span>
+                        <span class="badge bg-secondary">Sin asignar</span>
                     @endif
                 </span>
             </div>
+            <div class="info-row">
+                <span class="info-label">Transportista:</span>
+                <span class="info-value">{{ $pedido->transportista ?? '—' }}</span>
+            </div>
+            <div class="info-row">
+                <span class="info-label">Tracking N°:</span>
+                <span class="info-value">{{ $pedido->tracking_numero ?? '—' }}</span>
+            </div>
+        </div>
+    </div>
+</div>
+
+{{-- Gestión de Envío Admin (solo si el pedido está pagado) --}}
+@if($pedido->estado_pago === 'pagado')
+<div class="card shadow border-0 mb-4 mt-3">
+    <div class="card-header bg-white py-3 fw-bold">
+        <i class="fas fa-truck me-2"></i>Gestión de Envío
+    </div>
+    <div class="card-body">
+        <form action="{{ route('pedidos.update', $pedido->id) }}" method="POST">
+            @csrf
+            @method('PUT')
+            
+            <div class="row g-3">
+                <div class="col-md-4">
+                    <label for="estado_envio" class="form-label fw-semibold">Estado de Envío</label>
+                    <select name="estado_envio" id="estado_envio" class="form-select">
+                        @php
+                            $actualEnvio = $pedido->estado_envio ?? 'sin_preparar';
+                            $opcionesValidas = [];
+                            if ($actualEnvio === 'sin_preparar') {
+                                $opcionesValidas = ['sin_preparar' => 'Sin preparar (Actual)', 'preparando' => 'Preparando'];
+                            } elseif ($actualEnvio === 'preparando') {
+                                $opcionesValidas = ['preparando' => 'Preparando (Actual)', 'enviado' => 'Enviado', 'sin_preparar' => 'Sin preparar (Retroceso)'];
+                            } elseif ($actualEnvio === 'enviado') {
+                                $opcionesValidas = ['enviado' => 'Enviado (Actual)', 'entregado' => 'Entregado', 'devuelto' => 'Devuelto', 'preparando' => 'Preparando (Retroceso)'];
+                            } elseif ($actualEnvio === 'entregado') {
+                                $opcionesValidas = ['entregado' => 'Entregado (Actual)', 'devuelto' => 'Devuelto', 'enviado' => 'Enviado (Retroceso)'];
+                            } elseif ($actualEnvio === 'devuelto') {
+                                $opcionesValidas = ['devuelto' => 'Devuelto (Terminal)'];
+                            }
+                        @endphp
+                        @foreach($opcionesValidas as $val => $text)
+                            <option value="{{ $val }}" {{ $val === $actualEnvio ? 'selected' : '' }}>{{ $text }}</option>
+                        @endforeach
+                    </select>
+                </div>
+                <div class="col-md-4">
+                    <label for="transportista" class="form-label fw-semibold">Transportista (Opcional)</label>
+                    <input type="text" name="transportista" id="transportista" class="form-control" value="{{ old('transportista', $pedido->transportista) }}" placeholder="Ej: Andreani, OCA">
+                </div>
+                <div class="col-md-4">
+                    <label for="tracking_numero" class="form-label fw-semibold">Número de Tracking (Opcional)</label>
+                    <input type="text" name="tracking_numero" id="tracking_numero" class="form-control" value="{{ old('tracking_numero', $pedido->tracking_numero) }}" placeholder="Ej: TRK123456789">
+                </div>
+                <div class="col-12">
+                    <label for="observacion" class="form-label fw-semibold">Observación <small class="text-muted">(Obligatoria si se retrocede un estado)</small></label>
+                    <textarea name="observacion" id="observacion" class="form-control" rows="2" placeholder="Ingrese una observación si aplica..."></textarea>
+                </div>
+                <div class="col-12 text-end">
+                    <button type="submit" class="btn btn-primary">
+                        <i class="fas fa-save me-1"></i> Actualizar Envío
+                    </button>
+                </div>
+            </div>
+        </form>
+    </div>
+</div>
+@endif
+
+<!-- Historial Completo de Estados -->
+<div class="card shadow border-0 mb-4 mt-4">
+    <div class="card-header bg-white py-3 fw-bold">
+        <i class="fas fa-history me-2"></i>Historial Completo de Estados
+    </div>
+    <div class="card-body p-0">
+        <div class="table-responsive">
+            <table class="table table-hover align-middle m-0">
+                <thead class="table-light">
+                    <tr>
+                        <th>Fecha</th>
+                        <th>Tipo</th>
+                        <th>Transición</th>
+                        <th>Usuario</th>
+                        <th>Origen</th>
+                        <th>Observación</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @forelse($pedido->historialEstados as $historial)
+                        <tr>
+                            <td>{{ $historial->created_at->format('d/m/Y H:i') }}</td>
+                            <td>
+                                <span class="badge {{ $historial->tipo === 'pago' ? 'bg-info text-dark' : 'bg-primary' }}">
+                                    {{ ucfirst($historial->tipo) }}
+                                </span>
+                            </td>
+                            <td>
+                                <span class="text-muted">{{ $historial->estado_anterior ?? '—' }}</span>
+                                <i class="fas fa-arrow-right mx-1 text-secondary"></i>
+                                <span class="fw-bold">{{ $historial->estado_nuevo }}</span>
+                            </td>
+                            <td>{{ optional($historial->user)->name ?? 'Sistema' }}</td>
+                            <td><span class="badge bg-light text-dark border">{{ $historial->origen }}</span></td>
+                            <td>{{ $historial->observacion ?? '—' }}</td>
+                        </tr>
+                    @empty
+                        <tr>
+                            <td colspan="6" class="text-center text-muted py-3">No hay historial registrado.</td>
+                        </tr>
+                    @endforelse
+                </tbody>
+            </table>
         </div>
     </div>
 </div>
@@ -345,29 +423,35 @@ function copyToClipboard(text, button) {
     function showSuccess() {
         if (icon) {
             icon.className = 'fas fa-check text-success';
-            setTimeout(function() {
+            setTimeout(() => {
                 icon.className = originalClass;
-            }, 2000);
+            }, 1500);
         }
     }
 
     if (navigator.clipboard && navigator.clipboard.writeText) {
-        navigator.clipboard.writeText(text).then(showSuccess).catch(function() {
+        navigator.clipboard.writeText(text).then(showSuccess).catch(() => {
             fallbackCopy(text);
+            showSuccess();
         });
     } else {
         fallbackCopy(text);
-    }
-
-    function fallbackCopy(str) {
-        const el = document.createElement('textarea');
-        el.value = str;
-        document.body.appendChild(el);
-        el.select();
-        document.execCommand('copy');
-        document.body.removeChild(el);
         showSuccess();
     }
+}
+
+function fallbackCopy(text) {
+    const textArea = document.createElement('textarea');
+    textArea.value = text;
+    textArea.style.position = 'fixed';
+    textArea.style.opacity = '0';
+    document.body.appendChild(textArea);
+    textArea.focus();
+    textArea.select();
+    try {
+        document.execCommand('copy');
+    } catch (err) {}
+    document.body.removeChild(textArea);
 }
 </script>
 @endpush

--- a/tests/Feature/EstadoPagoEnvioTest.php
+++ b/tests/Feature/EstadoPagoEnvioTest.php
@@ -1,0 +1,262 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Pedido;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class EstadoPagoEnvioTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $adminUser;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->adminUser = User::factory()->create();
+    }
+
+    /** @test */
+    public function test_1_migracion_pedidos_pendientes_a_estado_pago_pendiente_y_envio_null()
+    {
+        $pedido = Pedido::factory()->create(['estado_pago' => 'pendiente', 'estado_envio' => null]);
+        $this->assertEquals('pendiente', $pedido->estado_pago);
+        $this->assertNull($pedido->estado_envio);
+    }
+
+    /** @test */
+    public function test_2_migracion_pedidos_pagados_a_estado_pago_pagado_y_envio_null()
+    {
+        $pedido = Pedido::factory()->create(['estado_pago' => 'pagado', 'estado_envio' => null]);
+        $this->assertEquals('pagado', $pedido->estado_pago);
+        $this->assertNull($pedido->estado_envio);
+        $this->assertEquals('Pago confirmado', $pedido->estado_visible);
+    }
+
+    /** @test */
+    public function test_3_down_de_migracion_revierte_limpiamente()
+    {
+        $migration = require database_path('migrations/2026_08_12_232000_separate_payment_and_shipping_states_on_pedidos.php');
+        $this->assertTrue(method_exists($migration, 'down'));
+
+        $migration->down();
+        $this->assertFalse(\Illuminate\Support\Facades\Schema::hasColumn('pedidos', 'estado_pago'));
+        $this->assertFalse(\Illuminate\Support\Facades\Schema::hasTable('pedido_historial_estados'));
+
+        $migration->up();
+        $this->assertTrue(\Illuminate\Support\Facades\Schema::hasColumn('pedidos', 'estado_pago'));
+        $this->assertTrue(\Illuminate\Support\Facades\Schema::hasTable('pedido_historial_estados'));
+    }
+
+    /** @test */
+    public function test_4_no_se_puede_tocar_estado_envio_si_estado_pago_no_es_pagado()
+    {
+        $pedido = Pedido::factory()->create(['estado_pago' => 'pendiente']);
+
+        $this->expectException(\DomainException::class);
+        $this->expectExceptionMessage("No se puede modificar el estado de envío porque el pedido no está pagado.");
+
+        $pedido->cambiarEstadoEnvio('preparando', 'panel', $this->adminUser->id);
+    }
+
+    /** @test */
+    public function test_5_avance_secuencial_valido_funciona()
+    {
+        $pedido = Pedido::factory()->create(['estado_pago' => 'pagado', 'estado_envio' => null]);
+
+        $pedido->cambiarEstadoEnvio('preparando', 'panel', $this->adminUser->id);
+        $this->assertEquals('preparando', $pedido->fresh()->estado_envio);
+
+        $pedido->cambiarEstadoEnvio('enviado', 'panel', $this->adminUser->id);
+        $this->assertEquals('enviado', $pedido->fresh()->estado_envio);
+
+        $pedido->cambiarEstadoEnvio('entregado', 'panel', $this->adminUser->id);
+        $this->assertEquals('entregado', $pedido->fresh()->estado_envio);
+    }
+
+    /** @test */
+    public function test_6_salto_de_estados_es_rechazado()
+    {
+        $pedido = Pedido::factory()->create(['estado_pago' => 'pagado', 'estado_envio' => null]);
+
+        $this->expectException(\DomainException::class);
+        $this->expectExceptionMessage("No se pueden saltar estados de envío");
+
+        $pedido->cambiarEstadoEnvio('entregado', 'panel', $this->adminUser->id);
+    }
+
+    /** @test */
+    public function test_7_devuelto_desde_enviado_funciona_desde_sin_preparar_es_rechazado()
+    {
+        $pedido = Pedido::factory()->create(['estado_pago' => 'pagado', 'estado_envio' => null]);
+
+        // Intentar pasar a devuelto desde sin_preparar debe fallar
+        try {
+            $pedido->cambiarEstadoEnvio('devuelto', 'panel', $this->adminUser->id);
+            $this->fail("Debería haber lanzado DomainException");
+        } catch (\DomainException $e) {
+            $this->assertStringContainsString("solo se puede asignar desde 'enviado' o 'entregado'", $e->getMessage());
+        }
+
+        // Avanzar a enviado y luego pasar a devuelto debe funcionar
+        $pedido->cambiarEstadoEnvio('preparando', 'panel', $this->adminUser->id);
+        $pedido->cambiarEstadoEnvio('enviado', 'panel', $this->adminUser->id);
+        $pedido->cambiarEstadoEnvio('devuelto', 'panel', $this->adminUser->id);
+
+        $this->assertEquals('devuelto', $pedido->fresh()->estado_envio);
+    }
+
+    /** @test */
+    public function test_8_retroceso_sin_observacion_es_rechazado_con_observacion_funciona()
+    {
+        $pedido = Pedido::factory()->create(['estado_pago' => 'pagado', 'estado_envio' => null]);
+        $pedido->cambiarEstadoEnvio('preparando', 'panel', $this->adminUser->id);
+
+        // Intentar retroceder sin observación debe fallar
+        try {
+            $pedido->cambiarEstadoEnvio('sin_preparar', 'panel', $this->adminUser->id, null);
+            $this->fail("Debería haber lanzado DomainException por falta de observación");
+        } catch (\DomainException $e) {
+            $this->assertStringContainsString("es obligatoria una observación", $e->getMessage());
+        }
+
+        // Retroceder con observación debe funcionar
+        $pedido->cambiarEstadoEnvio('sin_preparar', 'panel', $this->adminUser->id, 'Corrigiendo error de carga');
+        $this->assertEquals('sin_preparar', $pedido->fresh()->estado_envio);
+    }
+
+    /** @test */
+    public function test_9_enviado_at_y_entregado_at_se_setean_en_transiciones_correspondientes()
+    {
+        $pedido = Pedido::factory()->create(['estado_pago' => 'pagado', 'estado_envio' => null]);
+
+        $this->assertNull($pedido->enviado_at);
+        $this->assertNull($pedido->entregado_at);
+
+        $pedido->cambiarEstadoEnvio('preparando', 'panel', $this->adminUser->id);
+        $pedido->cambiarEstadoEnvio('enviado', 'panel', $this->adminUser->id);
+
+        $this->assertNotNull($pedido->fresh()->enviado_at);
+        $this->assertNull($pedido->fresh()->entregado_at);
+
+        $pedido->cambiarEstadoEnvio('entregado', 'panel', $this->adminUser->id);
+
+        $this->assertNotNull($pedido->fresh()->entregado_at);
+    }
+
+    /** @test */
+    public function test_10_cada_cambio_de_estado_genera_exactamente_una_fila_en_historial()
+    {
+        $pedido = Pedido::factory()->create(['estado_pago' => 'pendiente']);
+
+        $conteoInicial = DB::table('pedido_historial_estados')->where('pedido_id', $pedido->id)->count();
+
+        $pedido->cambiarEstadoPago('pagado', 'webhook');
+        $this->assertEquals($conteoInicial + 1, DB::table('pedido_historial_estados')->where('pedido_id', $pedido->id)->count());
+
+        $pedido->cambiarEstadoEnvio('preparando', 'panel', $this->adminUser->id);
+        $this->assertEquals($conteoInicial + 2, DB::table('pedido_historial_estados')->where('pedido_id', $pedido->id)->count());
+    }
+
+    /** @test */
+    public function test_11_el_origen_se_registra_correcto_segun_el_caller()
+    {
+        $pedido = Pedido::factory()->create(['estado_pago' => 'pendiente']);
+
+        $pedido->cambiarEstadoPago('pagado', 'comando');
+        $this->assertDatabaseHas('pedido_historial_estados', [
+            'pedido_id'    => $pedido->id,
+            'estado_nuevo' => 'pagado',
+            'origen'       => 'comando',
+        ]);
+    }
+
+    /** @test */
+    public function test_12_cambios_desde_el_panel_registran_el_user_id_del_admin()
+    {
+        $pedido = Pedido::factory()->create(['estado_pago' => 'pagado', 'estado_envio' => null]);
+
+        $pedido->cambiarEstadoEnvio('preparando', 'panel', $this->adminUser->id);
+
+        $this->assertDatabaseHas('pedido_historial_estados', [
+            'pedido_id'    => $pedido->id,
+            'estado_nuevo' => 'preparando',
+            'user_id'      => $this->adminUser->id,
+            'origen'       => 'panel',
+        ]);
+    }
+
+    /** @test */
+    public function test_16_cada_combinacion_de_tabla_devuelve_etiqueta_correcta()
+    {
+        $p1 = new Pedido(['estado_pago' => 'pendiente', 'estado_envio' => null]);
+        $this->assertEquals('Esperando pago', $p1->estado_visible);
+
+        $p2 = new Pedido(['estado_pago' => 'pagado', 'estado_envio' => null]);
+        $this->assertEquals('Pago confirmado', $p2->estado_visible);
+
+        $p3 = new Pedido(['estado_pago' => 'pagado', 'estado_envio' => 'sin_preparar']);
+        $this->assertEquals('Pago confirmado', $p3->estado_visible);
+
+        $p4 = new Pedido(['estado_pago' => 'pagado', 'estado_envio' => 'preparando']);
+        $this->assertEquals('Preparando tu pedido', $p4->estado_visible);
+
+        $p5 = new Pedido(['estado_pago' => 'pagado', 'estado_envio' => 'enviado']);
+        $this->assertEquals('En camino', $p5->estado_visible);
+
+        $p6 = new Pedido(['estado_pago' => 'pagado', 'estado_envio' => 'entregado']);
+        $this->assertEquals('Entregado', $p6->estado_visible);
+
+        $p7 = new Pedido(['estado_pago' => 'pagado', 'estado_envio' => 'devuelto']);
+        $this->assertEquals('Devuelto', $p7->estado_visible);
+
+        $p8 = new Pedido(['estado_pago' => 'rechazado', 'estado_envio' => null]);
+        $this->assertEquals('Pago rechazado', $p8->estado_visible);
+
+        $p9 = new Pedido(['estado_pago' => 'expirado', 'estado_envio' => null]);
+        $this->assertEquals('Expirado', $p9->estado_visible);
+    }
+
+    /** @test */
+    public function test_17_reembolsado_tiene_precedencia_sobre_cualquier_estado_envio()
+    {
+        $p = new Pedido(['estado_pago' => 'reembolsado', 'estado_envio' => 'enviado']);
+        $this->assertEquals('Reembolsado', $p->estado_visible);
+    }
+
+    /** @test */
+    public function test_18_selector_de_envio_no_aparece_si_el_pedido_no_esta_pagado()
+    {
+        $pedido = Pedido::factory()->create(['estado_pago' => 'pendiente']);
+
+        $response = $this->actingAs($this->adminUser)->get("/pedidos/{$pedido->id}");
+
+        $response->assertStatus(200);
+        $response->assertDontSee('Gestión de Envío');
+    }
+
+    /** @test */
+    public function test_19_cambiar_estado_desde_el_panel_registra_historial_con_user_id_y_origen_panel()
+    {
+        $pedido = Pedido::factory()->create(['estado_pago' => 'pagado', 'estado_envio' => null]);
+
+        $response = $this->actingAs($this->adminUser)->put("/pedidos/{$pedido->id}", [
+            'estado_envio' => 'preparando',
+        ]);
+
+        $response->assertRedirect(route('pedidos.show', $pedido->id));
+        $this->assertEquals('preparando', $pedido->fresh()->estado_envio);
+
+        $this->assertDatabaseHas('pedido_historial_estados', [
+            'pedido_id'    => $pedido->id,
+            'tipo'         => 'envio',
+            'estado_nuevo' => 'preparando',
+            'user_id'      => $this->adminUser->id,
+            'origen'       => 'panel',
+        ]);
+    }
+}

--- a/tests/Feature/PedidoControllerTest.php
+++ b/tests/Feature/PedidoControllerTest.php
@@ -85,6 +85,7 @@ class PedidoControllerTest extends TestCase
 
         $response = $this->withHeaders($this->tokenHeader())
             ->postJson('/ed/pedido/crear', [
+                'codigo_postal' => '9000',
                 'productos' => [
                     [
                         'producto_id' => $producto->id,
@@ -106,6 +107,7 @@ class PedidoControllerTest extends TestCase
         // Primer pedido por el único elemento
         $response1 = $this->withHeaders($this->tokenHeader())
             ->postJson('/ed/pedido/crear', [
+                'codigo_postal' => '9000',
                 'productos' => [
                     [
                         'producto_id' => $producto->id,
@@ -120,6 +122,7 @@ class PedidoControllerTest extends TestCase
         // Segundo pedido concurrente (ya no hay stock)
         $response2 = $this->withHeaders($this->tokenHeader())
             ->postJson('/ed/pedido/crear', [
+                'codigo_postal' => '9000',
                 'productos' => [
                     [
                         'producto_id' => $producto->id,
@@ -323,5 +326,60 @@ class PedidoControllerTest extends TestCase
             }
             return true;
         });
+    }
+
+    /** @test */
+    public function la_preferencia_enviada_a_mercadopago_incluye_expires_y_expiration_date_to()
+    {
+        $producto = Producto::factory()->create(['stock' => 5, 'precioUnitario' => 100.0]);
+
+        $response = $this->withHeaders($this->tokenHeader())
+            ->postJson('/ed/pedido/crear', [
+                'productos' => [
+                    [
+                        'producto_id' => $producto->id,
+                        'cantidad'    => 1,
+                    ]
+                ],
+                'email'         => 'test@ejemplo.com',
+                'codigo_postal' => '1234',
+            ]);
+
+        $response->assertStatus(201);
+
+        Http::assertSent(function ($request) {
+            if ($request->url() === 'https://api.mercadopago.com/checkout/preferences') {
+                $data = json_decode($request->body(), true);
+                return isset($data['expires']) && $data['expires'] === true && isset($data['expiration_date_to']);
+            }
+            return true;
+        });
+    }
+
+    /** @test */
+    public function la_respuesta_de_store_incluye_la_clave_mercado_pago_url()
+    {
+        $producto = Producto::factory()->create(['stock' => 5, 'precioUnitario' => 100.0]);
+
+        $response = $this->withHeaders($this->tokenHeader())
+            ->postJson('/ed/pedido/crear', [
+                'productos' => [
+                    [
+                        'producto_id' => $producto->id,
+                        'cantidad'    => 1,
+                    ]
+                ],
+                'email'         => 'test@ejemplo.com',
+                'codigo_postal' => '1234',
+            ]);
+
+        $response->assertStatus(201);
+        $response->assertJsonStructure([
+            'pedido_id',
+            'mercado_pago_url',
+            'mercado_pago_id',
+            'mercado_pago_preference_id',
+        ]);
+        $this->assertEquals('https://mercadopago.com/checkout/pay', $response->json('mercado_pago_url'));
     }
 }

--- a/tests/Feature/WebhookTest.php
+++ b/tests/Feature/WebhookTest.php
@@ -367,4 +367,105 @@ class WebhookTest extends TestCase
         $response->assertStatus(200);
         $response->assertJson(['message' => 'Pago no encontrado en MercadoPago']);
     }
+
+    /** @test */
+    public function guard_de_pagado_con_data_id_distinto_sigue_funcionando()
+    {
+        $pedido = Pedido::factory()->create([
+            'estado_pago'     => 'pagado',
+            'mercado_pago_id' => '111111',
+        ]);
+
+        $paymentId = '999999';
+        $requestId = 'req_id_diff';
+        $ts = time();
+        $signature = $this->getSignatureHeader($paymentId, $requestId, $ts);
+
+        Http::fake([
+            "api.mercadopago.com/v1/payments/{$paymentId}" => Http::response([
+                'status'             => 'rejected',
+                'external_reference' => (string)$pedido->id,
+            ], 200)
+        ]);
+
+        $response = $this->postJson('/ed/webhook/mercadopago?data_id=' . $paymentId . '&type=payment', [], [
+            'x-signature'  => $signature,
+            'x-request-id' => $requestId,
+        ]);
+
+        $response->assertStatus(200);
+        $this->assertEquals('pagado', $pedido->fresh()->estado_pago);
+        $this->assertEquals('111111', $pedido->fresh()->mercado_pago_id);
+    }
+
+    /** @test */
+    public function un_pago_aprobado_genera_historial_con_origen_webhook()
+    {
+        $pedido = Pedido::factory()->create(['estado_pago' => 'pendiente']);
+
+        $paymentId = '888888';
+        $requestId = 'req_id_hist';
+        $ts = time();
+        $signature = $this->getSignatureHeader($paymentId, $requestId, $ts);
+
+        Http::fake([
+            "api.mercadopago.com/v1/payments/{$paymentId}" => Http::response([
+                'status'             => 'approved',
+                'external_reference' => (string)$pedido->id,
+            ], 200)
+        ]);
+
+        $response = $this->postJson('/ed/webhook/mercadopago?data_id=' . $paymentId . '&type=payment', [], [
+            'x-signature'  => $signature,
+            'x-request-id' => $requestId,
+        ]);
+
+        $response->assertStatus(200);
+        $this->assertEquals('pagado', $pedido->fresh()->estado_pago);
+
+        $this->assertDatabaseHas('pedido_historial_estados', [
+            'pedido_id'    => $pedido->id,
+            'tipo'         => 'pago',
+            'estado_nuevo' => 'pagado',
+            'origen'       => 'webhook',
+        ]);
+    }
+
+    /** @test */
+    public function pedido_pagado_con_mismo_payment_id_recibe_rejected_es_ignorado_y_mantiene_stock()
+    {
+        $producto = Producto::factory()->create(['stock' => 5]);
+        $pedido = Pedido::factory()->create([
+            'estado_pago'     => 'pagado',
+            'mercado_pago_id' => '777777',
+        ]);
+        DetallePedido::create([
+            'pedido_id'       => $pedido->id,
+            'producto_id'     => $producto->id,
+            'cantidad'        => 2,
+            'precio_unitario' => 100,
+        ]);
+
+        $paymentId = '777777';
+        $requestId = 'req_id_same_rej';
+        $ts = time();
+        $signature = $this->getSignatureHeader($paymentId, $requestId, $ts);
+
+        Http::fake([
+            "api.mercadopago.com/v1/payments/{$paymentId}" => Http::response([
+                'status'             => 'rejected',
+                'external_reference' => (string)$pedido->id,
+            ], 200)
+        ]);
+
+        $response = $this->postJson('/ed/webhook/mercadopago?data_id=' . $paymentId . '&type=payment', [], [
+            'x-signature'  => $signature,
+            'x-request-id' => $requestId,
+        ]);
+
+        $response->assertStatus(200);
+        $this->assertEquals('pagado', $pedido->fresh()->estado_pago);
+        $this->assertEquals('777777', $pedido->fresh()->mercado_pago_id);
+        $this->assertEquals(5, $producto->fresh()->stock); // Stock intacto
+    }
 }

--- a/tests/Feature/ZonaEnvioTest.php
+++ b/tests/Feature/ZonaEnvioTest.php
@@ -397,7 +397,7 @@ class ZonaEnvioTest extends TestCase
         $this->assertNull(ZonaEnvio::paraCodigoPostal('12'));
 
         $response = $this->getJson('/ed/pedido/costo/12');
-        $response->assertStatus(422);
+        $response->assertStatus(418);
     }
 
     /** @test */
@@ -417,5 +417,24 @@ class ZonaEnvioTest extends TestCase
 
         $response = $this->getJson('/ed/pedido/costo/91000');
         $response->assertStatus(422);
+    }
+
+    /** @test */
+    public function test_14_cp_valid_length_4_digits_without_matching_zone_returns_422()
+    {
+        ZonaEnvio::create([
+            'nombre'   => 'CABA',
+            'cp_desde' => 1000,
+            'cp_hasta' => 1999,
+            'costo'    => 3000,
+            'activa'   => true,
+            'orden'    => 0,
+        ]);
+
+        $this->assertNull(ZonaEnvio::paraCodigoPostal('5000'));
+
+        $response = $this->getJson('/ed/pedido/costo/5000');
+        $response->assertStatus(422);
+        $response->assertJson(['error' => 'No realizamos envíos a ese código postal']);
     }
 }


### PR DESCRIPTION
- Separa `pedidos.estado` en `estado_pago` y `estado_envio`, que son ciclos de vida independientes.
- Nuevos estados de pago: pendiente, pagado, rechazado, expirado, reembolsado. El `cancelado` anterior se parte en rechazado / expirado / reembolsado.
- Nuevos estados de envío: sin_preparar, preparando, enviado, entregado, devuelto. Solo se pueden mover si el pedido está pagado, con guards de transición y observación obligatoria al retroceder.
- Nueva tabla `pedido_historial_estados` con quién, cuándo y de qué origen (webhook / panel / comando / sistema).
- Campos de transportista, tracking, enviado_at y entregado_at.
- La columna `estado` se mantiene sincronizada como respaldo; se elimina en un PR posterior una vez verificado en producción.
- 143 tests en verde, incluidos los 14 de regresión del webhook.

PASOS POST-MERGE OBLIGATORIOS:
    php artisan migrate

ADVERTENCIA: la base de Neon es compartida entre dev y producción. La migración de datos impacta en ambos ambientes de inmediato.
