### PR TITLE
fix(webhook): corregir ciclo de vida de pagos rechazados, reembolso condicional de stock y reserva 20m

### DIFF
--- a/app/Console/Commands/LiberarPedidosVencidos.php
+++ b/app/Console/Commands/LiberarPedidosVencidos.php
@@ -11,6 +11,8 @@ use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 use Carbon\Carbon;
 
+use App\Services\MercadoPagoConsultaService;
+
 class LiberarPedidosVencidos extends Command
 {
     /**
@@ -30,7 +32,7 @@ class LiberarPedidosVencidos extends Command
     /**
      * Execute the console command.
      */
-    public function handle()
+    public function handle(MercadoPagoConsultaService $mpConsultaService)
     {
         $this->info('Iniciando proceso de liberación de pedidos vencidos...');
         Log::info('LiberarPedidosVencidos: Iniciando proceso...');
@@ -61,41 +63,10 @@ class LiberarPedidosVencidos extends Command
                 ? $pedido->expira_at->toIso8601String() 
                 : $pedido->created_at->addHours($legacyHours)->toIso8601String() . " (Legacy Fallback)";
 
-            // Si tiene mercado_pago_id, verificar contra la API de MercadoPago
-            if ($pedido->mercado_pago_id) {
-                try {
-                    $response = Http::timeout(5)->withToken(config('services.mercadopago.access_token'))
-                        ->get("https://api.mercadopago.com/v1/payments/{$pedido->mercado_pago_id}");
-
-                    if ($response->successful()) {
-                        $paymentData = $response->json();
-                        $mpStatus = $paymentData['status'] ?? 'unknown';
-                        $dateOfExpiration = isset($paymentData['date_of_expiration']) 
-                            ? Carbon::parse($paymentData['date_of_expiration']) 
-                            : null;
-
-                        // Si el pago sigue pendiente en MP y su fecha de vencimiento NO ha pasado, NO cancelamos
-                        if ($mpStatus === 'pending' && $dateOfExpiration && $dateOfExpiration->isFuture()) {
-                            $this->line("Pedido #{$pedido->id} sigue pendiente y no venció en MercadoPago (Vence: {$dateOfExpiration->toIso8601String()}). Omitiendo.");
-                            continue;
-                        }
-                    } elseif ($response->status() !== 404) {
-                        // Si falla la API con un error distinto a 404 (ej. 500 o timeout), omitimos el pedido por seguridad
-                        $this->warn("Error al consultar pago {$pedido->mercado_pago_id} en MercadoPago (Status: {$response->status()}). Omitiendo pedido #{$pedido->id}.");
-                        Log::error("LiberarPedidosVencidos: Error de red/API al consultar pago {$pedido->mercado_pago_id}", [
-                            'pedido_id' => $pedido->id,
-                            'status_code' => $response->status()
-                        ]);
-                        continue;
-                    }
-                } catch (\Exception $e) {
-                    $this->error("Excepción al consultar pago {$pedido->mercado_pago_id}: {$e->getMessage()}. Omitiendo pedido #{$pedido->id}.");
-                    Log::error("LiberarPedidosVencidos: Excepción al consultar pago {$pedido->mercado_pago_id}", [
-                        'pedido_id' => $pedido->id,
-                        'exception' => $e->getMessage()
-                    ]);
-                    continue;
-                }
+            // Usar el servicio compartido para verificar si el pedido tiene un pago activo en MP
+            if ($mpConsultaService->tienePagoVivo($pedido)) {
+                $this->line("Pedido #{$pedido->id} tiene un pago activo en MercadoPago. Omitiendo.");
+                continue;
             }
 
             // Proceder a cancelar el pedido y reponer el stock transaccionalmente

--- a/app/Http/Controllers/CronController.php
+++ b/app/Http/Controllers/CronController.php
@@ -10,20 +10,27 @@ class CronController extends Controller
 {
     /**
      * Endpoint protegido para disparar la liberación de pedidos vencidos.
+     * Invocado por Vercel Cron vía GET con header `Authorization: Bearer <CRON_SECRET>`.
      */
     public function liberarPedidosVencidos(Request $request)
     {
-        $secret = env('CRON_SECRET');
-        $headerSecret = $request->header('x-cron-secret');
+        $secret = config('services.mercadopago.cron_secret', env('CRON_SECRET'));
+        $authHeader = $request->header('Authorization') ?? '';
 
-        if (empty($secret) || empty($headerSecret) || !hash_equals((string) $secret, (string) $headerSecret)) {
+        if (empty($secret) || empty($authHeader) || !str_starts_with($authHeader, 'Bearer ')) {
+            return response()->json(['error' => 'No autorizado'], 401);
+        }
+
+        $providedSecret = substr($authHeader, 7);
+
+        if (empty($providedSecret) || !hash_equals((string) $secret, (string) $providedSecret)) {
             return response()->json(['error' => 'No autorizado'], 401);
         }
 
         Artisan::call('pedidos:liberar-vencidos');
         $output = Artisan::output();
 
-        Log::info('CronController: Ejecutada liberación de pedidos vencidos vía endpoint HTTP cron');
+        Log::info('CronController: Ejecutada liberación de pedidos vencidos vía HTTP GET cron');
 
         return response()->json([
             'message' => 'Proceso de liberación completado',

--- a/app/Http/Controllers/CronController.php
+++ b/app/Http/Controllers/CronController.php
@@ -14,7 +14,7 @@ class CronController extends Controller
      */
     public function liberarPedidosVencidos(Request $request)
     {
-        $secret = config('services.mercadopago.cron_secret', env('CRON_SECRET'));
+        $secret = config('services.mercadopago.cron_secret');
         $authHeader = $request->header('Authorization') ?? '';
 
         if (empty($secret) || empty($authHeader) || !str_starts_with($authHeader, 'Bearer ')) {

--- a/app/Http/Controllers/CronController.php
+++ b/app/Http/Controllers/CronController.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Log;
+
+class CronController extends Controller
+{
+    /**
+     * Endpoint protegido para disparar la liberación de pedidos vencidos.
+     */
+    public function liberarPedidosVencidos(Request $request)
+    {
+        $secret = env('CRON_SECRET');
+        $headerSecret = $request->header('x-cron-secret');
+
+        if (empty($secret) || empty($headerSecret) || !hash_equals((string) $secret, (string) $headerSecret)) {
+            return response()->json(['error' => 'No autorizado'], 401);
+        }
+
+        Artisan::call('pedidos:liberar-vencidos');
+        $output = Artisan::output();
+
+        Log::info('CronController: Ejecutada liberación de pedidos vencidos vía endpoint HTTP cron');
+
+        return response()->json([
+            'message' => 'Proceso de liberación completado',
+            'output'  => trim($output),
+        ], 200);
+    }
+}

--- a/app/Http/Controllers/PedidoController.php
+++ b/app/Http/Controllers/PedidoController.php
@@ -374,8 +374,8 @@ class PedidoController extends Controller
             $totalProductos = 0;
             $detalles = [];
 
-            // Calcular expiración a partir de config/mercadopago.php
-            $expiracion = now()->addHours(config('mercadopago.expiration_hours', 72));
+            // Calcular expiración a partir de config/services.php (reserva_minutos, default 20)
+            $expiracion = now()->addMinutes(config('services.mercadopago.reserva_minutos', 20));
 
             $pedido = Pedido::create([
                 'user_id'       => $user->id,
@@ -532,6 +532,13 @@ class PedidoController extends Controller
                     'pending' => config('services.mercadopago.front_url') . '/pago/pending',
                 ],
                 'auto_return' => 'approved',
+                'binary_mode' => true,
+                'payment_methods' => [
+                    'excluded_payment_types' => [
+                        ['id' => 'ticket'],
+                        ['id' => 'atm'],
+                    ],
+                ],
                 'statement_descriptor' => 'ELCARTUCHO',
                 'expires' => true,
                 'expiration_date_to' => $pedido->expira_at->toIso8601String(),

--- a/app/Http/Controllers/WebhookController.php
+++ b/app/Http/Controllers/WebhookController.php
@@ -61,9 +61,75 @@ class WebhookController extends Controller
             return response()->json(['message' => 'Pago sin referencia de pedido'], 200);
         }
 
+        // Manejo de intentos rechazados / cancelados (no cambian estado_pago, no tocan stock)
+        if (in_array($status, ['rejected', 'cancelled'], true)) {
+            DB::beginTransaction();
+            try {
+                $pedido = Pedido::where('id', $pedidoId)->lockForUpdate()->first();
+
+                if (!$pedido) {
+                    DB::rollBack();
+                    Log::warning("Pedido no encontrado con ID externo: {$pedidoId}");
+                    return response()->json(['error' => 'Pedido no encontrado'], 404);
+                }
+
+                // Guard: si el pedido ya está en estado final (rechazado, expirado, reembolsado)
+                if (in_array($pedido->estado_pago, ['rechazado', 'expirado', 'reembolsado'], true)) {
+                    DB::commit();
+                    Log::warning("Notificación rejected/cancelled ignorada para pedido en estado final #{$pedido->id}.", [
+                        'pedido_id'     => $pedido->id,
+                        'estado_actual' => $pedido->estado_pago,
+                        'payment_id'    => $dataId,
+                    ]);
+                    return response()->json(['message' => 'Transición no permitida desde cancelado'], 200);
+                }
+
+                // Guard: si el pedido ya está pagado
+                if ($pedido->estado_pago === 'pagado') {
+                    DB::commit();
+                    Log::warning("Notificación rejected/cancelled ignorada para pedido ya pagado #{$pedido->id}.", [
+                        'pedido_id'         => $pedido->id,
+                        'payment_id_evento' => $dataId,
+                    ]);
+                    return response()->json(['message' => 'Transición no permitida desde pagado para este pago'], 200);
+                }
+
+                // Idempotencia: Verificar si este intento ya fue registrado en el historial para este dataId
+                $yaRegistrado = \App\Models\PedidoHistorialEstado::where('pedido_id', $pedido->id)
+                    ->where('observacion', 'like', "%{$dataId}%")
+                    ->exists();
+
+                if ($yaRegistrado) {
+                    DB::commit();
+                    return response()->json(['message' => 'Notificación duplicada ya procesada'], 200);
+                }
+
+                // Registrar intento fallido en historial sin cambiar estado_pago ni tocar stock
+                \App\Models\PedidoHistorialEstado::create([
+                    'pedido_id'       => $pedido->id,
+                    'tipo'            => 'pago',
+                    'estado_anterior' => $pedido->estado_pago,
+                    'estado_nuevo'    => $pedido->estado_pago,
+                    'user_id'         => null,
+                    'origen'          => 'webhook',
+                    'observacion'     => "intento_rechazado: Intento de pago {$status} (Payment ID: {$dataId})",
+                    'created_at'      => now(),
+                ]);
+
+                DB::commit();
+                Log::info("Intento de pago {$status} registrado para pedido #{$pedido->id} (Payment ID: {$dataId}). Estado permanece: {$pedido->estado_pago}.");
+                return response()->json(['message' => 'OK'], 200);
+            } catch (\Exception $e) {
+                DB::rollBack();
+                Log::error("Error al procesar intento rechazado para pedido {$pedidoId}", [
+                    'error' => $e->getMessage()
+                ]);
+                return response()->json(['error' => 'Error interno al procesar el pago'], 500);
+            }
+        }
+
         $targetStatePago = match ($status) {
             'approved'                                           => 'pagado',
-            'rejected', 'cancelled'                             => 'rechazado',
             'refunded', 'charged_back'                          => 'reembolsado',
             'pending', 'in_process', 'authorized', 'in_mediation' => 'pendiente',
             default                                              => null,
@@ -99,10 +165,10 @@ class WebhookController extends Controller
                 return response()->json(['message' => 'Transición no permitida desde cancelado'], 200);
             }
 
-            // 2) Desde 'pagado' solo se permite pasar a 'reembolsado' o 'rechazado' si $dataId coincide con mercado_pago_id del pedido
+            // 2) Desde 'pagado' solo se permite pasar a 'reembolsado' si $dataId coincide con mercado_pago_id del pedido
             if ($pedido->estado_pago === 'pagado') {
                 $esMismoPago = ($pedido->mercado_pago_id !== null && (string)$pedido->mercado_pago_id === (string)$dataId);
-                $esReembolsoValido = $esMismoPago && in_array($status, ['refunded', 'charged_back', 'cancelled']);
+                $esReembolsoValido = $esMismoPago && in_array($status, ['refunded', 'charged_back']);
 
                 if (!$esReembolsoValido) {
                     DB::commit();
@@ -127,20 +193,32 @@ class WebhookController extends Controller
                     $pedido->cambiarEstadoPago('pagado', 'webhook');
                     Log::info("Pedido {$pedido->id} actualizado a estado_pago: pagado");
                 }
-            } elseif (in_array($targetStatePago, ['rechazado', 'reembolsado'], true)) {
-                if ($pedido->estado_pago !== $targetStatePago) {
-                    $pedido->cambiarEstadoPago($targetStatePago, 'webhook');
+            } elseif ($targetStatePago === 'reembolsado') {
+                if ($pedido->estado_pago !== 'reembolsado') {
+                    $estadoEnvio = $pedido->estado_envio;
+                    $reponerStock = ($estadoEnvio === null || in_array($estadoEnvio, ['sin_preparar', 'preparando'], true));
 
-                    // Reponer el stock
-                    $detalles = DetallePedido::where('pedido_id', $pedido->id)->get();
-                    foreach ($detalles as $detalle) {
-                        $producto = Producto::where('id', $detalle->producto_id)->lockForUpdate()->first();
-                        if ($producto) {
-                            $producto->stock += $detalle->cantidad;
-                            $producto->save();
+                    if ($reponerStock) {
+                        $pedido->cambiarEstadoPago('reembolsado', 'webhook');
+                        // Reponer el stock
+                        $detalles = DetallePedido::where('pedido_id', $pedido->id)->get();
+                        foreach ($detalles as $detalle) {
+                            $producto = Producto::where('id', $detalle->producto_id)->lockForUpdate()->first();
+                            if ($producto) {
+                                $producto->stock += $detalle->cantidad;
+                                $producto->save();
+                            }
                         }
+                        Log::info("Pedido {$pedido->id} actualizado a estado_pago: reembolsado. Stock repuesto (estado_envio: {$estadoEnvio}).");
+                    } else {
+                        // Si ya fue enviado, entregado o devuelto: NO tocar stock
+                        $pedido->cambiarEstadoPago('reembolsado', 'webhook', null, 'reembolso_sin_reposicion');
+                        Log::warning("Reembolso procesado para Pedido #{$pedido->id} sin reposición de stock (estado_envio: {$estadoEnvio}).", [
+                            'pedido_id'    => $pedido->id,
+                            'estado_envio' => $estadoEnvio,
+                            'payment_id'   => $dataId,
+                        ]);
                     }
-                    Log::info("Pedido {$pedido->id} actualizado a estado_pago: {$targetStatePago} (Pago fallido/reembolsado: {$status}). Stock repuesto.");
                 }
             } elseif ($targetStatePago === 'pendiente') {
                 if ($pedido->estado_pago !== 'pendiente') {

--- a/app/Services/MercadoPagoConsultaService.php
+++ b/app/Services/MercadoPagoConsultaService.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Pedido;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+use Carbon\Carbon;
+
+class MercadoPagoConsultaService
+{
+    /**
+     * Consulta la API de Mercado Pago y determina si existe algún pago activo
+     * (approved, authorized, in_process, o pending no vencido) para el pedido.
+     */
+    public function tienePagoVivo(Pedido $pedido): bool
+    {
+        $accessToken = config('services.mercadopago.access_token');
+        if (!$accessToken) {
+            Log::error('MercadoPagoConsultaService: access_token no configurado');
+            return false;
+        }
+
+        // 1. Si el pedido ya tiene un mercado_pago_id asociado, consultar ese pago específico
+        if ($pedido->mercado_pago_id) {
+            try {
+                $response = Http::timeout(5)
+                    ->withToken($accessToken)
+                    ->get("https://api.mercadopago.com/v1/payments/{$pedido->mercado_pago_id}");
+
+                if ($response->successful()) {
+                    $paymentData = $response->json();
+                    $mpStatus = $paymentData['status'] ?? 'unknown';
+                    $dateOfExpiration = isset($paymentData['date_of_expiration'])
+                        ? Carbon::parse($paymentData['date_of_expiration'])
+                        : null;
+
+                    if (in_array($mpStatus, ['approved', 'authorized', 'in_process'], true)) {
+                        return true;
+                    }
+
+                    if ($mpStatus === 'pending' && $dateOfExpiration && $dateOfExpiration->isFuture()) {
+                        return true;
+                    }
+
+                    return false;
+                } elseif ($response->status() !== 404) {
+                    Log::error("MercadoPagoConsultaService: Error HTTP {$response->status()} al consultar pago {$pedido->mercado_pago_id}", [
+                        'pedido_id' => $pedido->id,
+                    ]);
+                    return true;
+                }
+            } catch (\Exception $e) {
+                Log::error("MercadoPagoConsultaService: Excepción al consultar pago {$pedido->mercado_pago_id}", [
+                    'pedido_id' => $pedido->id,
+                    'error'     => $e->getMessage(),
+                ]);
+                return true;
+            }
+        }
+
+        // 2. Consultar por external_reference (ID del pedido) para detectar cualquier pago activo en MP
+        try {
+            $searchResponse = Http::timeout(5)
+                ->withToken($accessToken)
+                ->get('https://api.mercadopago.com/v1/payments/search', [
+                    'external_reference' => (string) $pedido->id,
+                ]);
+
+            if ($searchResponse->successful()) {
+                $results = $searchResponse->json('results') ?? [];
+                foreach ($results as $payment) {
+                    $pStatus = $payment['status'] ?? '';
+                    $dateOfExpiration = isset($payment['date_of_expiration'])
+                        ? Carbon::parse($payment['date_of_expiration'])
+                        : null;
+
+                    if (in_array($pStatus, ['approved', 'authorized', 'in_process'], true)) {
+                        return true;
+                    }
+
+                    if ($pStatus === 'pending' && $dateOfExpiration && $dateOfExpiration->isFuture()) {
+                        return true;
+                    }
+                }
+            }
+        } catch (\Exception $e) {
+            // Error en búsqueda sin mercado_pago_id -> omitir
+        }
+
+        return false;
+    }
+}

--- a/app/Services/MercadoPagoConsultaService.php
+++ b/app/Services/MercadoPagoConsultaService.php
@@ -48,14 +48,14 @@ class MercadoPagoConsultaService
                     Log::error("MercadoPagoConsultaService: Error HTTP {$response->status()} al consultar pago {$pedido->mercado_pago_id}", [
                         'pedido_id' => $pedido->id,
                     ]);
-                    return true;
+                    return true; // Ante error de API distinto de 404, por seguridad NO cancelar
                 }
             } catch (\Exception $e) {
                 Log::error("MercadoPagoConsultaService: Excepción al consultar pago {$pedido->mercado_pago_id}", [
                     'pedido_id' => $pedido->id,
                     'error'     => $e->getMessage(),
                 ]);
-                return true;
+                return true; // Ante excepción de red, por seguridad NO cancelar
             }
         }
 
@@ -83,9 +83,18 @@ class MercadoPagoConsultaService
                         return true;
                     }
                 }
+            } elseif ($searchResponse->status() !== 404) {
+                Log::error("MercadoPagoConsultaService: Error HTTP {$searchResponse->status()} al buscar pagos por external_reference", [
+                    'pedido_id' => $pedido->id,
+                ]);
+                return true; // Ante error de API distinto de 404, por seguridad NO cancelar
             }
         } catch (\Exception $e) {
-            // Error en búsqueda sin mercado_pago_id -> omitir
+            Log::error("MercadoPagoConsultaService: Excepción al buscar pagos por external_reference", [
+                'pedido_id' => $pedido->id,
+                'error'     => $e->getMessage(),
+            ]);
+            return true; // Ante excepción de red, por seguridad NO cancelar
         }
 
         return false;

--- a/config/services.php
+++ b/config/services.php
@@ -39,6 +39,7 @@ return [
         'access_token' => env('MERCADO_PAGO_ACCESS_TOKEN'),
         'webhook_secret' => env('WEBHOOK_SECRET_TOKEN'),
         'front_url' => env('FRONT_URL'),
+        'reserva_minutos' => (int) env('PEDIDO_RESERVA_MINUTOS', 20),
     ],
 
 ];

--- a/config/services.php
+++ b/config/services.php
@@ -40,6 +40,7 @@ return [
         'webhook_secret' => env('WEBHOOK_SECRET_TOKEN'),
         'front_url' => env('FRONT_URL'),
         'reserva_minutos' => (int) env('PEDIDO_RESERVA_MINUTOS', 20),
+        'cron_secret' => env('CRON_SECRET'),
     ],
 
 ];

--- a/routes/api.php
+++ b/routes/api.php
@@ -17,7 +17,7 @@ use App\Http\Controllers\CronController;
 Route::post('/webhook/mercadopago', [WebhookController::class, 'handle']);
 
 #Cron
-Route::post('/cron/liberar-vencidos', [CronController::class, 'liberarPedidosVencidos']);
+Route::get('/cron/liberar-vencidos', [CronController::class, 'liberarPedidosVencidos']);
 
 #Productos
 Route::get('/producto/listar', [ProductoController::class, 'buscar']);

--- a/routes/api.php
+++ b/routes/api.php
@@ -9,11 +9,15 @@ use App\Http\Controllers\CategoriaController;
 use App\Http\Controllers\ProfileController;
 use App\Http\Controllers\CarritoController;
 use App\Http\Controllers\WishlistController;
+use App\Http\Controllers\CronController;
 
 // ─── Sin autenticación ───────────────────────────────────────────────────────
 
 #Mercado Pago
 Route::post('/webhook/mercadopago', [WebhookController::class, 'handle']);
+
+#Cron
+Route::post('/cron/liberar-vencidos', [CronController::class, 'liberarPedidosVencidos']);
 
 #Productos
 Route::get('/producto/listar', [ProductoController::class, 'buscar']);

--- a/tests/Feature/CronLiberarVencidosTest.php
+++ b/tests/Feature/CronLiberarVencidosTest.php
@@ -14,7 +14,21 @@ class CronLiberarVencidosTest extends TestCase
     {
         putenv('CRON_SECRET=super_secret_cron_token');
 
-        $response = $this->postJson('/ed/cron/liberar-vencidos');
+        $response = $this->getJson('/ed/cron/liberar-vencidos');
+
+        $response->assertStatus(401);
+        $response->assertJson(['error' => 'No autorizado']);
+    }
+
+    /** @test */
+    public function request_with_malformed_authorization_header_returns_401()
+    {
+        putenv('CRON_SECRET=super_secret_cron_token');
+
+        // Header presente pero sin el prefijo "Bearer "
+        $response = $this->getJson('/ed/cron/liberar-vencidos', [
+            'Authorization' => 'super_secret_cron_token',
+        ]);
 
         $response->assertStatus(401);
         $response->assertJson(['error' => 'No autorizado']);
@@ -25,8 +39,8 @@ class CronLiberarVencidosTest extends TestCase
     {
         putenv('CRON_SECRET=super_secret_cron_token');
 
-        $response = $this->postJson('/ed/cron/liberar-vencidos', [], [
-            'x-cron-secret' => 'wrong_secret_token',
+        $response = $this->getJson('/ed/cron/liberar-vencidos', [
+            'Authorization' => 'Bearer wrong_secret_token',
         ]);
 
         $response->assertStatus(401);
@@ -38,8 +52,8 @@ class CronLiberarVencidosTest extends TestCase
     {
         putenv('CRON_SECRET=super_secret_cron_token');
 
-        $response = $this->postJson('/ed/cron/liberar-vencidos', [], [
-            'x-cron-secret' => 'super_secret_cron_token',
+        $response = $this->getJson('/ed/cron/liberar-vencidos', [
+            'Authorization' => 'Bearer super_secret_cron_token',
         ]);
 
         $response->assertStatus(200);

--- a/tests/Feature/CronLiberarVencidosTest.php
+++ b/tests/Feature/CronLiberarVencidosTest.php
@@ -3,17 +3,22 @@
 namespace Tests\Feature;
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Config;
 use Tests\TestCase;
 
 class CronLiberarVencidosTest extends TestCase
 {
     use RefreshDatabase;
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Config::set('services.mercadopago.cron_secret', 'super_secret_cron_token');
+    }
+
     /** @test */
     public function request_without_cron_secret_returns_401()
     {
-        putenv('CRON_SECRET=super_secret_cron_token');
-
         $response = $this->getJson('/ed/cron/liberar-vencidos');
 
         $response->assertStatus(401);
@@ -23,8 +28,6 @@ class CronLiberarVencidosTest extends TestCase
     /** @test */
     public function request_with_malformed_authorization_header_returns_401()
     {
-        putenv('CRON_SECRET=super_secret_cron_token');
-
         // Header presente pero sin el prefijo "Bearer "
         $response = $this->getJson('/ed/cron/liberar-vencidos', [
             'Authorization' => 'super_secret_cron_token',
@@ -37,8 +40,6 @@ class CronLiberarVencidosTest extends TestCase
     /** @test */
     public function request_with_incorrect_cron_secret_returns_401()
     {
-        putenv('CRON_SECRET=super_secret_cron_token');
-
         $response = $this->getJson('/ed/cron/liberar-vencidos', [
             'Authorization' => 'Bearer wrong_secret_token',
         ]);
@@ -50,8 +51,6 @@ class CronLiberarVencidosTest extends TestCase
     /** @test */
     public function request_with_correct_cron_secret_returns_200()
     {
-        putenv('CRON_SECRET=super_secret_cron_token');
-
         $response = $this->getJson('/ed/cron/liberar-vencidos', [
             'Authorization' => 'Bearer super_secret_cron_token',
         ]);

--- a/tests/Feature/CronLiberarVencidosTest.php
+++ b/tests/Feature/CronLiberarVencidosTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class CronLiberarVencidosTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    public function request_without_cron_secret_returns_401()
+    {
+        putenv('CRON_SECRET=super_secret_cron_token');
+
+        $response = $this->postJson('/ed/cron/liberar-vencidos');
+
+        $response->assertStatus(401);
+        $response->assertJson(['error' => 'No autorizado']);
+    }
+
+    /** @test */
+    public function request_with_incorrect_cron_secret_returns_401()
+    {
+        putenv('CRON_SECRET=super_secret_cron_token');
+
+        $response = $this->postJson('/ed/cron/liberar-vencidos', [], [
+            'x-cron-secret' => 'wrong_secret_token',
+        ]);
+
+        $response->assertStatus(401);
+        $response->assertJson(['error' => 'No autorizado']);
+    }
+
+    /** @test */
+    public function request_with_correct_cron_secret_returns_200()
+    {
+        putenv('CRON_SECRET=super_secret_cron_token');
+
+        $response = $this->postJson('/ed/cron/liberar-vencidos', [], [
+            'x-cron-secret' => 'super_secret_cron_token',
+        ]);
+
+        $response->assertStatus(200);
+        $response->assertJsonStructure(['message', 'output']);
+        $response->assertJson(['message' => 'Proceso de liberación completado']);
+    }
+}

--- a/tests/Feature/LiberarPedidosVencidosTest.php
+++ b/tests/Feature/LiberarPedidosVencidosTest.php
@@ -26,6 +26,10 @@ class LiberarPedidosVencidosTest extends TestCase
     /** @test */
     public function command_cancels_expired_pending_order_without_mercado_pago_id()
     {
+        Http::fake([
+            'https://api.mercadopago.com/v1/payments/search*' => Http::response(['results' => []], 200),
+        ]);
+
         $producto = Producto::factory()->create(['stock' => 10]);
         $pedido = Pedido::factory()->create([
             'estado' => 'pendiente',
@@ -111,6 +115,10 @@ class LiberarPedidosVencidosTest extends TestCase
     /** @test */
     public function command_cancels_legacy_pending_order_older_than_96_hours()
     {
+        Http::fake([
+            'https://api.mercadopago.com/v1/payments/search*' => Http::response(['results' => []], 200),
+        ]);
+
         $producto = Producto::factory()->create(['stock' => 10]);
         $pedido = Pedido::factory()->create([
             'estado' => 'pendiente',
@@ -157,6 +165,10 @@ class LiberarPedidosVencidosTest extends TestCase
     /** @test */
     public function command_run_twice_does_not_restore_stock_twice()
     {
+        Http::fake([
+            'https://api.mercadopago.com/v1/payments/search*' => Http::response(['results' => []], 200),
+        ]);
+
         $producto = Producto::factory()->create(['stock' => 10]);
         $pedido = Pedido::factory()->create([
             'estado' => 'pendiente',
@@ -212,5 +224,73 @@ class LiberarPedidosVencidosTest extends TestCase
         $this->assertEquals('pagado', $pedidoPagado->fresh()->estado);
         $this->assertEquals('cancelado', $pedidoCancelado->fresh()->estado);
         $this->assertEquals(10, $producto->fresh()->stock); // No se alteró stock
+    }
+
+    /** @test */
+    public function command_does_not_cancel_order_when_mp_search_fails_with_http_error()
+    {
+        $producto = Producto::factory()->create(['stock' => 10]);
+        $pedido = Pedido::factory()->create([
+            'estado'          => 'pendiente',
+            'expira_at'       => now()->subMinutes(1),
+            'mercado_pago_id' => null,
+        ]);
+
+        DetallePedido::create([
+            'pedido_id'       => $pedido->id,
+            'producto_id'     => $producto->id,
+            'cantidad'        => 2,
+            'precio_unitario' => $producto->precioUnitario,
+        ]);
+
+        // Simular que la búsqueda por external_reference falla con HTTP 500
+        Http::fake([
+            'https://api.mercadopago.com/v1/payments/search*' => Http::response([
+                'message' => 'Internal Server Error'
+            ], 500)
+        ]);
+
+        Artisan::call('pedidos:liberar-vencidos');
+
+        // Por seguridad (fail closed), el pedido NO debe cancelarse si MP falló con 500
+        $this->assertEquals('pendiente', $pedido->fresh()->estado);
+        $this->assertEquals(10, $producto->fresh()->stock);
+    }
+
+    /** @test */
+    public function command_does_not_cancel_order_when_mp_search_finds_active_approved_payment()
+    {
+        $producto = Producto::factory()->create(['stock' => 10]);
+        $pedido = Pedido::factory()->create([
+            'estado'          => 'pendiente',
+            'expira_at'       => now()->subMinutes(1),
+            'mercado_pago_id' => null,
+        ]);
+
+        DetallePedido::create([
+            'pedido_id'       => $pedido->id,
+            'producto_id'     => $producto->id,
+            'cantidad'        => 2,
+            'precio_unitario' => $producto->precioUnitario,
+        ]);
+
+        // Simular que la búsqueda por external_reference detecta un pago aprobado en MP
+        Http::fake([
+            'https://api.mercadopago.com/v1/payments/search*' => Http::response([
+                'results' => [
+                    [
+                        'id'                 => 999111222,
+                        'status'             => 'approved',
+                        'external_reference' => (string) $pedido->id,
+                    ]
+                ]
+            ], 200)
+        ]);
+
+        Artisan::call('pedidos:liberar-vencidos');
+
+        // Al existir un pago aprobado detectado en la búsqueda, no debe cancelarse
+        $this->assertEquals('pendiente', $pedido->fresh()->estado);
+        $this->assertEquals(10, $producto->fresh()->stock);
     }
 }

--- a/tests/Feature/PedidoControllerTest.php
+++ b/tests/Feature/PedidoControllerTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature;
 
 use App\Models\Producto;
+use App\Models\Pedido;
 use App\Models\User;
 use Firebase\JWT\JWT;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -381,5 +382,68 @@ class PedidoControllerTest extends TestCase
             'mercado_pago_preference_id',
         ]);
         $this->assertEquals('https://mercadopago.com/checkout/pay', $response->json('mercado_pago_url'));
+    }
+
+    /** @test */
+    public function la_preferencia_incluye_binary_mode_y_excluye_ticket_y_atm()
+    {
+        $producto = Producto::factory()->create(['stock' => 5, 'precioUnitario' => 100.0]);
+
+        $response = $this->withHeaders($this->tokenHeader())
+            ->postJson('/ed/pedido/crear', [
+                'productos' => [
+                    [
+                        'producto_id' => $producto->id,
+                        'cantidad'    => 1,
+                    ]
+                ],
+                'email'         => 'test@ejemplo.com',
+                'codigo_postal' => '1234',
+            ]);
+
+        $response->assertStatus(201);
+
+        Http::assertSent(function ($request) {
+            if ($request->url() === 'https://api.mercadopago.com/checkout/preferences') {
+                $data = json_decode($request->body(), true);
+                $binaryMode = isset($data['binary_mode']) && $data['binary_mode'] === true;
+                $excludedTypes = $data['payment_methods']['excluded_payment_types'] ?? [];
+                $hasTicket = false;
+                $hasAtm = false;
+                foreach ($excludedTypes as $item) {
+                    if (($item['id'] ?? '') === 'ticket') $hasTicket = true;
+                    if (($item['id'] ?? '') === 'atm') $hasAtm = true;
+                }
+                return $binaryMode && $hasTicket && $hasAtm;
+            }
+            return true;
+        });
+    }
+
+    /** @test */
+    public function expira_at_queda_a_20_minutos_de_la_creacion()
+    {
+        $producto = Producto::factory()->create(['stock' => 5, 'precioUnitario' => 100.0]);
+
+        $response = $this->withHeaders($this->tokenHeader())
+            ->postJson('/ed/pedido/crear', [
+                'productos' => [
+                    [
+                        'producto_id' => $producto->id,
+                        'cantidad'    => 1,
+                    ]
+                ],
+                'email'         => 'test@ejemplo.com',
+                'codigo_postal' => '1234',
+            ]);
+
+        $response->assertStatus(201);
+        $pedidoId = $response->json('pedido_id');
+        $pedido = Pedido::find($pedidoId);
+
+        $this->assertNotNull($pedido->expira_at);
+        $diffInMinutes = now()->diffInMinutes($pedido->expira_at, false);
+        $this->assertGreaterThanOrEqual(19, $diffInMinutes);
+        $this->assertLessThanOrEqual(21, $diffInMinutes);
     }
 }

--- a/tests/Feature/WebhookTest.php
+++ b/tests/Feature/WebhookTest.php
@@ -161,7 +161,7 @@ class WebhookTest extends TestCase
     public function test_5b_repeated_rejected_notification_returns_200_without_duplicate_stock_restoration()
     {
         $producto = Producto::factory()->create(['stock' => 10]);
-        $pedido = Pedido::factory()->create(['estado' => 'pendiente']);
+        $pedido = Pedido::factory()->create(['estado_pago' => 'pendiente']);
 
         DetallePedido::create([
             'pedido_id' => $pedido->id,
@@ -182,32 +182,96 @@ class WebhookTest extends TestCase
             ], 200)
         ]);
 
-        // Primer envío
+        // Primer envío: rejected sobre pedido pendiente
         $res1 = $this->postJson('/ed/webhook/mercadopago?data_id=' . $paymentId . '&type=payment', [], [
             'x-signature' => $signature,
             'x-request-id' => $requestId
         ]);
         $res1->assertStatus(200);
-        $this->assertEquals('cancelado', $pedido->fresh()->estado);
-        // Stock repuesto una vez: 10 + 3 = 13
-        $this->assertEquals(13, $producto->fresh()->stock);
+        $this->assertEquals('pendiente', $pedido->fresh()->estado_pago);
+        // Stock intacto: no se modifica
+        $this->assertEquals(10, $producto->fresh()->stock);
 
-        // Segundo envío
+        // Se creó registro en el historial
+        $this->assertDatabaseHas('pedido_historial_estados', [
+            'pedido_id' => $pedido->id,
+            'origen'    => 'webhook',
+        ]);
+
+        // Segundo envío: duplicado
         $res2 = $this->postJson('/ed/webhook/mercadopago?data_id=' . $paymentId . '&type=payment', [], [
             'x-signature' => $signature,
             'x-request-id' => $requestId
         ]);
         $res2->assertStatus(200);
         $res2->assertJson(['message' => 'Notificación duplicada ya procesada']);
-        // Stock no debe reponerse por segunda vez
-        $this->assertEquals(13, $producto->fresh()->stock);
+        $this->assertEquals('pendiente', $pedido->fresh()->estado_pago);
+        $this->assertEquals(10, $producto->fresh()->stock);
+    }
+
+    /** @test */
+    public function rejected_seguido_de_approved_con_distintos_payment_ids_termina_pagado()
+    {
+        $producto = Producto::factory()->create(['stock' => 10]);
+        $pedido = Pedido::factory()->create(['estado_pago' => 'pendiente']);
+
+        DetallePedido::create([
+            'pedido_id' => $pedido->id,
+            'producto_id' => $producto->id,
+            'cantidad' => 2,
+            'precio_unitario' => $producto->precioUnitario
+        ]);
+
+        $paymentId1 = '111111111';
+        $requestId1 = 'req_id_rej_1';
+        $ts1 = time();
+        $signature1 = $this->getSignatureHeader($paymentId1, $requestId1, $ts1);
+
+        Http::fake([
+            "api.mercadopago.com/v1/payments/{$paymentId1}" => Http::response([
+                'status' => 'rejected',
+                'external_reference' => (string)$pedido->id
+            ], 200)
+        ]);
+
+        // 1. Webhook de pago #1 rechazado
+        $res1 = $this->postJson('/ed/webhook/mercadopago?data_id=' . $paymentId1 . '&type=payment', [], [
+            'x-signature'  => $signature1,
+            'x-request-id' => $requestId1
+        ]);
+        $res1->assertStatus(200);
+        $this->assertEquals('pendiente', $pedido->fresh()->estado_pago);
+        $this->assertEquals(10, $producto->fresh()->stock);
+
+        // 2. Webhook de pago #2 aprobado
+        $paymentId2 = '222222222';
+        $requestId2 = 'req_id_app_2';
+        $ts2 = time() + 1;
+        $signature2 = $this->getSignatureHeader($paymentId2, $requestId2, $ts2);
+
+        Http::fake([
+            "api.mercadopago.com/v1/payments/{$paymentId2}" => Http::response([
+                'status' => 'approved',
+                'external_reference' => (string)$pedido->id
+            ], 200)
+        ]);
+
+        $res2 = $this->postJson('/ed/webhook/mercadopago?data_id=' . $paymentId2 . '&type=payment', [], [
+            'x-signature'  => $signature2,
+            'x-request-id' => $requestId2
+        ]);
+        $res2->assertStatus(200);
+
+        // El pedido debe terminar pagado
+        $this->assertEquals('pagado', $pedido->fresh()->estado_pago);
+        $this->assertEquals($paymentId2, $pedido->fresh()->mercado_pago_id);
     }
 
     /** @test */
     public function test_5c_late_approved_notification_for_cancelled_order_is_ignored()
     {
         $producto = Producto::factory()->create(['stock' => 10]);
-        $pedido = Pedido::factory()->create(['estado' => 'cancelado', 'mercado_pago_id' => null]);
+        $pedido = Pedido::factory()->create(['estado_pago' => 'expirado', 'estado' => 'cancelado', 'mercado_pago_id' => null]);
 
         DetallePedido::create([
             'pedido_id' => $pedido->id,
@@ -235,9 +299,7 @@ class WebhookTest extends TestCase
 
         $response->assertStatus(200);
         $response->assertJson(['message' => 'Transición no permitida desde cancelado']);
-        // Debe permanecer cancelado
-        $this->assertEquals('cancelado', $pedido->fresh()->estado);
-        // mercado_pago_id no debe ser sobrescrito
+        $this->assertEquals('expirado', $pedido->fresh()->estado_pago);
         $this->assertNull($pedido->fresh()->mercado_pago_id);
     }
 
@@ -246,7 +308,8 @@ class WebhookTest extends TestCase
     {
         $producto = Producto::factory()->create(['stock' => 10]);
         $pedido = Pedido::factory()->create([
-            'estado' => 'pagado',
+            'estado_pago'     => 'pagado',
+            'estado'          => 'pagado',
             'mercado_pago_id' => 'payment_A'
         ]);
 
@@ -276,20 +339,19 @@ class WebhookTest extends TestCase
 
         $response->assertStatus(200);
         $response->assertJson(['message' => 'Transición no permitida desde pagado para este pago']);
-        // Permanece pagado y mercado_pago_id sigue siendo payment_A
-        $this->assertEquals('pagado', $pedido->fresh()->estado);
+        $this->assertEquals('pagado', $pedido->fresh()->estado_pago);
         $this->assertEquals('payment_A', $pedido->fresh()->mercado_pago_id);
-        // El stock no se altera
         $this->assertEquals(10, $producto->fresh()->stock);
     }
 
     /** @test */
-    public function test_5e_refunded_notification_for_matching_payment_on_paid_order_transitions_to_cancelled_and_restores_stock()
+    public function refunded_con_estado_envio_sin_preparar_reponed_stock()
     {
         $producto = Producto::factory()->create(['stock' => 10]);
         $paymentA = 'payment_A';
         $pedido = Pedido::factory()->create([
-            'estado' => 'pagado',
+            'estado_pago'     => 'pagado',
+            'estado_envio'    => 'sin_preparar',
             'mercado_pago_id' => $paymentA
         ]);
 
@@ -300,7 +362,7 @@ class WebhookTest extends TestCase
             'precio_unitario' => $producto->precioUnitario
         ]);
 
-        $requestId = 'req_id_refund';
+        $requestId = 'req_id_refund_sin_prep';
         $ts = time();
         $signature = $this->getSignatureHeader($paymentA, $requestId, $ts);
 
@@ -317,10 +379,56 @@ class WebhookTest extends TestCase
         ]);
 
         $response->assertStatus(200);
-        $this->assertEquals('cancelado', $pedido->fresh()->estado);
-        $this->assertEquals($paymentA, $pedido->fresh()->mercado_pago_id);
+        $this->assertEquals('reembolsado', $pedido->fresh()->estado_pago);
         // Stock repuesto: 10 + 4 = 14
         $this->assertEquals(14, $producto->fresh()->stock);
+    }
+
+    /** @test */
+    public function refunded_con_estado_envio_enviado_no_reponed_stock_y_cambia_estado_pago()
+    {
+        $producto = Producto::factory()->create(['stock' => 10]);
+        $paymentA = 'payment_A';
+        $pedido = Pedido::factory()->create([
+            'estado_pago'     => 'pagado',
+            'estado_envio'    => 'enviado',
+            'mercado_pago_id' => $paymentA
+        ]);
+
+        DetallePedido::create([
+            'pedido_id' => $pedido->id,
+            'producto_id' => $producto->id,
+            'cantidad' => 4,
+            'precio_unitario' => $producto->precioUnitario
+        ]);
+
+        $requestId = 'req_id_refund_enviado';
+        $ts = time();
+        $signature = $this->getSignatureHeader($paymentA, $requestId, $ts);
+
+        Http::fake([
+            "api.mercadopago.com/v1/payments/{$paymentA}" => Http::response([
+                'status' => 'refunded',
+                'external_reference' => (string)$pedido->id
+            ], 200)
+        ]);
+
+        $response = $this->postJson('/ed/webhook/mercadopago?data_id=' . $paymentA . '&type=payment', [], [
+            'x-signature' => $signature,
+            'x-request-id' => $requestId
+        ]);
+
+        $response->assertStatus(200);
+        $this->assertEquals('reembolsado', $pedido->fresh()->estado_pago);
+        // Stock NO repuesto: permanece 10
+        $this->assertEquals(10, $producto->fresh()->stock);
+
+        // Se registró en historial con observacion de reembolso sin reposición
+        $this->assertDatabaseHas('pedido_historial_estados', [
+            'pedido_id'   => $pedido->id,
+            'estado_nuevo' => 'reembolsado',
+            'observacion' => 'reembolso_sin_reposicion',
+        ]);
     }
 
     /** @test */

--- a/tests/Feature/WebhookTest.php
+++ b/tests/Feature/WebhookTest.php
@@ -158,7 +158,7 @@ class WebhookTest extends TestCase
     }
 
     /** @test */
-    public function test_5b_repeated_rejected_notification_returns_200_without_duplicate_stock_restoration()
+    public function test_5b_repeated_rejected_notification_is_idempotent_and_does_not_duplicate_history_entry()
     {
         $producto = Producto::factory()->create(['stock' => 10]);
         $pedido = Pedido::factory()->create(['estado_pago' => 'pendiente']);
@@ -192,13 +192,10 @@ class WebhookTest extends TestCase
         // Stock intacto: no se modifica
         $this->assertEquals(10, $producto->fresh()->stock);
 
-        // Se creó registro en el historial
-        $this->assertDatabaseHas('pedido_historial_estados', [
-            'pedido_id' => $pedido->id,
-            'origen'    => 'webhook',
-        ]);
+        // Se creó exactamente 1 registro en el historial
+        $this->assertEquals(1, \App\Models\PedidoHistorialEstado::where('pedido_id', $pedido->id)->count());
 
-        // Segundo envío: duplicado
+        // Segundo envío: duplicado con el mismo payment_id
         $res2 = $this->postJson('/ed/webhook/mercadopago?data_id=' . $paymentId . '&type=payment', [], [
             'x-signature' => $signature,
             'x-request-id' => $requestId
@@ -207,6 +204,9 @@ class WebhookTest extends TestCase
         $res2->assertJson(['message' => 'Notificación duplicada ya procesada']);
         $this->assertEquals('pendiente', $pedido->fresh()->estado_pago);
         $this->assertEquals(10, $producto->fresh()->stock);
+
+        // El registro en el historial no se duplicó
+        $this->assertEquals(1, \App\Models\PedidoHistorialEstado::where('pedido_id', $pedido->id)->count());
     }
 
     /** @test */

--- a/vercel.json
+++ b/vercel.json
@@ -17,5 +17,5 @@
         "dest": "api/index.php"
       }
     ],
-    "_comment_crons": "Cron /ed/cron/liberar-vencidos pendiente de activacion y definicion de frecuencia segun plan de Vercel"
+    "_comment_crons": "Cron GET /ed/cron/liberar-vencidos pendiente de activacion y definicion de frecuencia segun plan de Vercel (Authorization: Bearer <CRON_SECRET>)"
   }

--- a/vercel.json
+++ b/vercel.json
@@ -16,5 +16,6 @@
         "src": "/(.*)",
         "dest": "api/index.php"
       }
-    ]
+    ],
+    "_comment_crons": "Cron /ed/cron/liberar-vencidos pendiente de activacion y definicion de frecuencia segun plan de Vercel"
   }

--- a/vercel.json
+++ b/vercel.json
@@ -16,6 +16,5 @@
         "src": "/(.*)",
         "dest": "api/index.php"
       }
-    ],
-    "_comment_crons": "Cron GET /ed/cron/liberar-vencidos pendiente de activacion y definicion de frecuencia segun plan de Vercel (Authorization: Bearer <CRON_SECRET>)"
+    ]
   }


### PR DESCRIPTION
## Cambios incluidos
- WebhookController: los intentos ejected/cancelled dejan estado_pago en pendiente sin tocar stock y registran intento en historial.
- WebhookController: efunded/charged_back solo reponen stock si estado_envio es 
ull, sin_preparar o preparando.
- PedidoController: preferencia MP con inary_mode y exclusión de 	icket/tm. Reserva de stock a 20 minutos (expira_at).
- MercadoPagoConsultaService: servicio extraído para consultar pagos vivos en MP antes de liberar.
- CronController: endpoint GET /ed/cron/liberar-vencidos protegido por header Authorization: Bearer <CRON_SECRET> (comparado con hash_equals).

## Reporte
- Valor previo de expira_at: 72 horas.
- Frecuencia de cron: Pendiente de definir según plan Vercel.